### PR TITLE
Combine tools into main parol command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["parser", "parsing", "parser-generator", "LLk"]
 categories = ["algorithms", "parsing", "Parsing tools"]
 license = "MIT"
 edition = "2018"
+# Gives tools poor names (without prefixes). See issue #2
+autobins = false
+default-run = "parol"
 
 [dependencies]
 bart = "0.1.4"
@@ -35,3 +38,52 @@ features = [ "suggestions", "color", "yaml" ]
 
 [profile.release]
 debug = true
+
+[[bin]]
+name = "parol"
+
+# Prefix all the tool names with parol-<tool> to avoid polluting the path
+#
+# Otherwise `cargo install` will install them directly into $PATH
+# See issue #2
+#
+# The main binary picks up these subcommands automatically and runs them as external tools.
+[[bin]]
+name = "parol-calculate-k"
+path = "src/bin/calculate_k.rs"
+
+[[bin]]
+name = "parol-calculate-k-tuples"
+path = "src/bin/calculate_k_tuples.rs"
+
+[[bin]]
+name = "parol-decidable"
+path = "src/bin/decidable.rs"
+
+[[bin]]
+name = "parol-first"
+path = "src/bin/first.rs"
+
+[[bin]]
+name = "parol-follow"
+path = "src/bin/follow.rs"
+
+[[bin]]
+name = "parol-format"
+path = "src/bin/format.rs"
+
+[[bin]]
+name = "parol-left-factor"
+path = "src/bin/left_factor.rs"
+
+[[bin]]
+name = "parol-left-recursions"
+path = "src/bin/left_recursions.rs"
+
+[[bin]]
+name = "parol-productivity"
+path = "src/bin/productivity.rs"
+
+[[bin]]
+name = "parol-serialize"
+path = "src/bin/serialize.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ keywords = ["parser", "parsing", "parser-generator", "LLk"]
 categories = ["algorithms", "parsing", "Parsing tools"]
 license = "MIT"
 edition = "2018"
-# Gives tools poor names (without prefixes). See issue #2
-autobins = false
-default-run = "parol"
 
 [dependencies]
 bart = "0.1.4"
@@ -38,52 +35,3 @@ features = [ "suggestions", "color", "yaml" ]
 
 [profile.release]
 debug = true
-
-[[bin]]
-name = "parol"
-
-# Prefix all the tool names with parol-<tool> to avoid polluting the path
-#
-# Otherwise `cargo install` will install them directly into $PATH
-# See issue #2
-#
-# The main binary picks up these subcommands automatically and runs them as external tools.
-[[bin]]
-name = "parol-calculate-k"
-path = "src/bin/calculate_k.rs"
-
-[[bin]]
-name = "parol-calculate-k-tuples"
-path = "src/bin/calculate_k_tuples.rs"
-
-[[bin]]
-name = "parol-decidable"
-path = "src/bin/decidable.rs"
-
-[[bin]]
-name = "parol-first"
-path = "src/bin/first.rs"
-
-[[bin]]
-name = "parol-follow"
-path = "src/bin/follow.rs"
-
-[[bin]]
-name = "parol-format"
-path = "src/bin/format.rs"
-
-[[bin]]
-name = "parol-left-factor"
-path = "src/bin/left_factor.rs"
-
-[[bin]]
-name = "parol-left-recursions"
-path = "src/bin/left_recursions.rs"
-
-[[bin]]
-name = "parol-productivity"
-path = "src/bin/productivity.rs"
-
-[[bin]]
-name = "parol-serialize"
-path = "src/bin/serialize.rs"

--- a/src/bin/parol/tools.rs
+++ b/src/bin/parol/tools.rs
@@ -1,0 +1,32 @@
+//! A registry for all the extra tools that can be used with parol.
+
+pub type ToolFunc = fn(&[&str]) -> miette::Result<()>;
+
+pub fn get_tool_main(name: &str) -> Option<ToolFunc> {
+    TOOLS.iter().find(|(actual_name, _)| *actual_name == name).map(|tool| tool.1)    
+}
+
+pub fn names() -> impl Iterator<Item=&'static str> {
+    TOOLS.iter().map(|(name, _)| *name)
+}
+
+/*
+ * For each specified tool name this
+ *
+ * 1. Declares `mod $tool`
+ * 2. Registers it in the table of tools
+ */
+macro_rules! declare_tools {
+    ($($tool:ident),*) => {
+        $(mod $tool;)*
+        pub static TOOLS: &[(&str, ToolFunc)] = &[
+            $((stringify!($tool), self::$tool::main)),*
+        ];
+    }
+}
+
+declare_tools!(
+    calculate_k, calculate_k_tuples, decidable, first, follow,
+    format, left_factor, left_recursions, productivity, serialize
+);
+

--- a/src/bin/parol/tools/calculate_k.rs
+++ b/src/bin/parol/tools/calculate_k.rs
@@ -1,10 +1,8 @@
 use miette::{bail, Result};
 use parol::analysis::k_decision::{calculate_k, FirstCache, FollowCache};
 use parol::{obtain_grammar_config, MAX_K};
-use std::env;
 
-fn main() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
+pub fn main(args: &[&str]) -> Result<()> {
     if args.len() > 1 {
         let file_name = args[1].clone();
 

--- a/src/bin/parol/tools/calculate_k_tuples.rs
+++ b/src/bin/parol/tools/calculate_k_tuples.rs
@@ -3,10 +3,8 @@ use parol::analysis::k_decision::{calculate_k_tuples, FirstCache, FollowCache};
 use parol::generators::generate_terminal_names;
 use parol::obtain_grammar_config;
 use parol::MAX_K;
-use std::env;
 
-fn main() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
+pub fn main(args: &[&str]) -> Result<()> {
     if args.len() > 1 {
         let file_name = args[1].clone();
 

--- a/src/bin/parol/tools/decidable.rs
+++ b/src/bin/parol/tools/decidable.rs
@@ -1,16 +1,11 @@
-use log::trace;
 use miette::{bail, Result};
 use parol::analysis::{decidable, explain_conflicts, FirstCache, FollowCache};
 use parol::generators::generate_terminal_names;
 use parol::obtain_grammar_config;
 use parol::MAX_K;
-use std::env;
 
-fn main() -> Result<()> {
-    env_logger::init();
-    trace!("env logger started");
-
-    let args: Vec<String> = env::args().collect();
+pub fn main(args: &[&str]) -> Result<()> {
+    // NOTE: Logger should already be initialized
     if args.len() > 1 {
         let file_name = args[1].clone();
 

--- a/src/bin/parol/tools/first.rs
+++ b/src/bin/parol/tools/first.rs
@@ -1,17 +1,15 @@
-use log::debug;
 use miette::{bail, Result};
 use parol::analysis::{first_k, FirstCache};
 use parol::generators::generate_terminal_names;
 use parol::{obtain_grammar_config, KTuples, MAX_K};
 use std::collections::BTreeMap;
-use std::env;
 
-fn main() -> Result<()> {
-    env_logger::init();
+pub fn main(args: &[&str]) -> Result<()> {
+    // NOTE: Logger should already be started
+    // env_logger::init();
     // $env:RUST_LOG="parol,parol_runtime=off,productivity=debug"
-    debug!("env logger started");
+    // debug!("env logger started");
 
-    let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         println!("Missing arguments <par-file> [k=1]!");
         println!(

--- a/src/bin/parol/tools/follow.rs
+++ b/src/bin/parol/tools/follow.rs
@@ -1,17 +1,15 @@
-use log::debug;
 use miette::{bail, Result};
 use parol::analysis::follow_k;
 use parol::analysis::FirstCache;
 use parol::generators::generate_terminal_names;
 use parol::{obtain_grammar_config, MAX_K};
-use std::env;
 
-fn main() -> Result<()> {
-    env_logger::init();
+pub fn main(args: &[&str]) -> Result<()> {
+    // NOTE: Logger already initalized
+    // env_logger::init();
     // $env:RUST_LOG="parol,parol_runtime=off,productivity=debug"
-    debug!("env logger started");
+    // debug!("env logger started");
 
-    let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         println!("Missing arguments <par-file> [k=1]!");
         println!(

--- a/src/bin/parol/tools/format.rs
+++ b/src/bin/parol/tools/format.rs
@@ -1,17 +1,12 @@
 use miette::Result;
+use parol::conversions::par::render_par_string;
 use parol::obtain_grammar_config;
-use std::env;
 
-fn main() -> Result<()> {
-    env_logger::init();
-    let args: Vec<String> = env::args().collect();
+pub fn main(args: &[&str]) -> Result<()> {
     if args.len() > 1 {
         let file_name = args[1].clone();
         let grammar_config = obtain_grammar_config(&file_name, false)?;
-        let serialized = serde_json::to_string(&grammar_config).unwrap();
-        println!("{}", serialized);
-        let cfg_ext1 = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(grammar_config, cfg_ext1);
+        println!("{}", render_par_string(&grammar_config, true));
     } else {
         println!("Missing arguments <par-file>!");
         println!(

--- a/src/bin/parol/tools/left_factor.rs
+++ b/src/bin/parol/tools/left_factor.rs
@@ -1,9 +1,7 @@
 use miette::Result;
 use parol::{left_factor, obtain_grammar_config};
-use std::env;
 
-fn main() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
+pub fn main(args: &[&str]) -> Result<()> {
     if args.len() > 1 {
         let file_name = args[1].clone();
 

--- a/src/bin/parol/tools/left_recursions.rs
+++ b/src/bin/parol/tools/left_recursions.rs
@@ -1,9 +1,7 @@
 use miette::Result;
 use parol::{detect_left_recursions, obtain_grammar_config};
-use std::env;
 
-fn main() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
+pub fn main(args: &[&str]) -> Result<()> {
     if args.len() > 1 {
         let file_name = args[1].clone();
         let grammar_config = obtain_grammar_config(&file_name, false)?;

--- a/src/bin/parol/tools/productivity.rs
+++ b/src/bin/parol/tools/productivity.rs
@@ -1,15 +1,13 @@
-use log::debug;
 use miette::Result;
 use parol::analysis::non_productive_non_terminals;
 use parol::obtain_grammar_config;
-use std::env;
 
-fn main() -> Result<()> {
-    env_logger::init();
+pub fn main(args: &[&str]) -> Result<()> {
+    // Logger already initialized
+    // env_logger::init();
     // $env:RUST_LOG="parol,parol_runtime=off,productivity=debug"
-    debug!("env logger started");
+    // debug!("env logger started");
 
-    let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         println!("Missing arguments <par-file>!");
         println!(

--- a/src/bin/parol/tools/serialize.rs
+++ b/src/bin/parol/tools/serialize.rs
@@ -1,15 +1,14 @@
 use miette::Result;
-use parol::conversions::par::render_par_string;
 use parol::obtain_grammar_config;
-use std::env;
 
-fn main() -> Result<()> {
-    env_logger::init();
-    let args: Vec<String> = env::args().collect();
+pub fn main(args: &[&str]) -> Result<()> {
     if args.len() > 1 {
         let file_name = args[1].clone();
         let grammar_config = obtain_grammar_config(&file_name, false)?;
-        println!("{}", render_par_string(&grammar_config, true));
+        let serialized = serde_json::to_string(&grammar_config).unwrap();
+        println!("{}", serialized);
+        let cfg_ext1 = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(grammar_config, cfg_ext1);
     } else {
         println!("Missing arguments <par-file>!");
         println!(


### PR DESCRIPTION
Fixes #2 

Basically, the problem is that by default, `cargo install parol` will install commands like `follow` and `serialize` directly onto the $PATH.

This is bad because it's unclear those commands come from parol, and it could possibly cause conflicts.

This fixes it by combining all the tools into the main parol binary and allowing them to be invoked as subcommands.

In addition to clearing up the $PATH, this also provides significant space savings (33.3MB of tools -> single 5.8 MB binary)

NOTE: This has multiple commits to reflect the full development history. I only intend to submit the final version 😉  If you want, I can squash everything together into one big happy commit.