### PR TITLE
Fix newline issue in scanner states (#5)

### DIFF
--- a/examples/scanner_states/scanner_states-exp.par
+++ b/examples/scanner_states/scanner_states-exp.par
@@ -20,6 +20,6 @@
 /*  9 */ StringElement: NoneQuote;
 /* 10 */ Identifier: "[a-zA-Z_]\w*";
 /* 11 */ Escaped: <String>"\u{5c}[\u{22}\u{5c}bfnt]";
-/* 12 */ EscapedLineEnd: <String>"\u{5c}[\s*]\r?\n";
+/* 12 */ EscapedLineEnd: <String>"\u{5c}[\s^\n\r]*\r?\n";
 /* 13 */ NoneQuote: <String>"[^\u{22}\u{5c}]+";
 /* 14 */ StringDelimiter: <INITIAL, String>"\u{22}";

--- a/examples/scanner_states/scanner_states.par
+++ b/examples/scanner_states/scanner_states.par
@@ -60,7 +60,9 @@ Escaped
 
 EscapedLineEnd
     // This terminal is only valid in scanner state 'String'
-    : <String>"\u{5c}[\s*]\r?\n"
+    // NOTE: [\s^\n\r] matches all whitespace characters *except* \r and \n
+    // Otherwise, the regex will greedly pickup newlines See issue #5
+    : <String>"\u{5c}[\s^\n\r]*\r?\n"
     ;
 
 NoneQuote

--- a/examples/scanner_states/scanner_states_grammar_trait.rs
+++ b/examples/scanner_states/scanner_states_grammar_trait.rs
@@ -162,7 +162,7 @@ pub trait ScannerStatesGrammarTrait {
 
     /// Semantic action for production 12:
     ///
-    /// EscapedLineEnd: <String>"\u{5c}[\s*]\r?\n";
+    /// EscapedLineEnd: <String>"\u{5c}[\s^\n\r]*\r?\n";
     ///
     fn escaped_line_end_12(
         &mut self,

--- a/examples/scanner_states/scanner_states_parser.rs
+++ b/examples/scanner_states/scanner_states_parser.rs
@@ -25,7 +25,7 @@ pub const TERMINALS: &[&str; 11] = &[
     /*  4 */ UNMATCHABLE_TOKEN,
     /*  5 */ r###"[a-zA-Z_]\w*"###,
     /*  6 */ r###"\u{5c}[\u{22}\u{5c}bfnt]"###,
-    /*  7 */ r###"\u{5c}[\s*]\r?\n"###,
+    /*  7 */ r###"\u{5c}[\s^\n\r]*\r?\n"###,
     /*  8 */ r###"[^\u{22}\u{5c}]+"###,
     /*  9 */ r###"\u{22}"###,
     /* 10 */ ERROR_TOKEN,
@@ -232,7 +232,7 @@ pub const PRODUCTIONS: &[Production; 15] = &[
         lhs: 1,
         production: &[ParseType::T(6)],
     },
-    // 12 - EscapedLineEnd: "\u{5c}[\s*]\r?\n";
+    // 12 - EscapedLineEnd: "\u{5c}[\s^\n\r]*\r?\n";
     Production {
         lhs: 2,
         production: &[ParseType::T(7)],


### PR DESCRIPTION
The old production for `EscapedLineEnd` ended with `[\s]*\r?\n`

The problem with this is that `\s*` is a greedy match,
it will match as many whitespace characters as it can, overriding the
`\r?\n` matching at the end.

This problem only appears to show up on Mac and Linux (for some reason).

I have confirmed that this fixes the problem on my Macbook and my Arch Laptop.

Fixes issue #5