### PR TITLE
Clap 3.0 (derive + builder styles)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 bart = "0.1.4"
 bart_derive = "0.1.4"
-clap = { version = "2.33.3", default-features = false, features = [ "suggestions", "color", "yaml" ] }
+clap = { version = "3.0.0", features = [ "derive", "cargo" ] }
 env_logger = "0.9.0"
 id_tree = "1.8.0"
 id_tree_layout = "2.0.2"

--- a/src/bin/parol/main.rs
+++ b/src/bin/parol/main.rs
@@ -1,10 +1,11 @@
 #[macro_use]
 extern crate clap;
 
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use clap::{App, AppSettings};
+use clap::{App, AppSettings, Arg, Parser};
 use log::trace;
 use miette::{miette, IntoDiagnostic, Result, WrapErr};
 
@@ -15,9 +16,158 @@ use parol::{
 };
 use parol_runtime::parser::ParseTreeType;
 
-static VERSION: &str = env!("CARGO_PKG_VERSION");
+// static VERSION: &str = env!("CARGO_PKG_VERSION");
 
 mod tools;
+
+#[derive(Parser)]
+#[clap(
+    author = "Jörg Singer <singer.joerg@gmx.de>",
+    version,
+    about = "A LL(k) Parser Generator written in Rust.",
+    long_about = None,
+    setting(AppSettings::ArgsNegateSubcommands),
+)]
+struct ClapApp {
+    /// Input grammar file
+    #[clap(short = 'f', long = "file", parse(from_os_str))]
+    grammar: Option<PathBuf>,
+
+    /// Lookahead limit for Lookahead DFA calculation
+    #[clap(short = 'k', long = "lookahead", default_value = "5")]
+    lookahead: usize,
+
+    /// Output file for the generated parser source
+    #[clap(short = 'p', long = "parser", parse(from_os_str))]
+    parser: Option<PathBuf>,
+
+    /// Output file for the expanded grammar. Use -e-- to output to stdout
+    #[clap(short = 'e', long = "expanded", parse(from_os_str))]
+    expanded: Option<PathBuf>,
+
+    /// Writes the internal parsed grammar (ParolGrammar)
+    #[clap(short = 'i', long = "write_internal", parse(from_os_str))]
+    write_internal: Option<PathBuf>,
+
+    /// Writes the untransformed parsed grammar
+    #[clap(short = 'u', long = "write_untransformed", parse(from_os_str))]
+    write_untransformed: Option<PathBuf>,
+
+    /// Writes the transformed parsed grammar
+    #[clap(short = 'w', long = "write_transformed", parse(from_os_str))]
+    write_transformed: Option<PathBuf>,
+
+    /// Output file for the generated trait with semantic actions
+    #[clap(short = 'a', long = "actions", parse(from_os_str))]
+    actions: Option<PathBuf>,
+
+    /// User type that implements the language processing
+    #[clap(short = 't', long = "user_type")]
+    user_type: Option<String>,
+
+    /// User type's module name
+    #[clap(short = 'm', long = "module")]
+    module: Option<String>,
+
+    /// Activates the generation of a SVG file with the parse tree of the given grammar
+    #[clap(short = 's', long = "svg")]
+    generate_tree_graph: bool,
+
+    /// Increased verbosity
+    #[clap(short = 'v', long = "verbose")]
+    verbose: bool,
+
+    #[clap(subcommand)]
+    subcommand: Option<tools::ToolsSubcommands>,
+}
+
+fn clap_app() -> App<'static> {
+    App::new("parol")
+        .author("Jörg Singer <singer.joerg@gmx.de>")
+        .about("A LL(k) Parser Generator written in Rust.")
+        .arg(
+            Arg::new("grammar")
+                .help("Input grammar file")
+                .short('f')
+                .long("file")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new("lookahead")
+                .help("Lookahead limit for Lookahead DFA calculation")
+                .short('k')
+                .long("lookahead")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new("parser")
+                .help("Output file for the generated parser source")
+                .short('p')
+                .long("parser")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new("expanded")
+                .help("Output file for the expanded grammar. Use -e-- to output to stdout")
+                .short('e')
+                .long("expanded")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new("write_internal")
+                .help("Writes the internal parsed grammar (ParolGrammar)")
+                .short('i')
+                .long("write_internal")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new("write_untransformed")
+                .help("Writes the untransformed parsed grammar")
+                .short('u')
+                .long("write_untransformed")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new("write_transformed")
+                .help("Writes the transformed parsed grammar")
+                .short('w')
+                .long("write_transformed")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new("actions")
+                .help("Output file for the generated trait with semantic actions")
+                .short('a')
+                .long("actions")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new("user_type")
+                .help("User type that implements the language processing")
+                .short('t')
+                .long("user_type")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new("module")
+                .help("User type's module name")
+                .short('m')
+                .long("module")
+                .takes_value(true)
+        )
+        .arg(
+            Arg::new("generate_tree_graph")
+                .help("Activates the generation of a SVG file with the parse tree of the given grammar")
+                .short('s')
+                .long("svg")
+        )
+        .arg(
+            Arg::new("verbose")
+                .help("Increased verbosity")
+                .short('v')
+                .long("verbose")
+        )
+}
 
 // To rebuild the parser sources from scratch use the command build_parsers.ps1
 
@@ -25,32 +175,40 @@ fn main() -> Result<()> {
     env_logger::try_init().into_diagnostic()?;
     trace!("env logger started");
 
-    let yaml = load_yaml!("arguments.yml");
-    let config = App::from_yaml(yaml)
-        /*
-         * We want all our "tools" to be registered as subcommands.
-         *
-         * Doing this allows `clap` to give better help and error messages
-         * then if we used AppSettings::AllowExternalSubcommands
-         */
-        .subcommands(tools::names().map(|name| {
-            /*
-             * For now, our subcommands have no names or descriptions
-             *
-             * They all accept infinite args (clap makes no attempt to validate things here).
-             */
-            tools::get_tool_sub_command(name).unwrap()()
-        }))
-        // Only invoke tools if they come first, to avoid ambiguity with main binary
-        .setting(AppSettings::ArgsNegateSubcommands)
-        .version(VERSION)
-        .get_matches();
+    // let config = clap_app()
+    /*
+     * We want all our "tools" to be registered as subcommands.
+     *
+     * Doing this allows `clap` to give better help and error messages
+     * then if we used AppSettings::AllowExternalSubcommands
+     */
+    // .subcommands(tools::names().map(|name| {
+    //     /*
+    //      * For now, our subcommands have no names or descriptions
+    //      *
+    //      * They all accept infinite args (clap makes no attempt to validate things here).
+    //      */
+    //     tools::get_tool_sub_command(name).unwrap()()
+    // }))
 
-    if let (subcommand_name, Some(sub_matches)) = config.subcommand() {
-        let tool_main =
-            tools::get_tool_main(subcommand_name).expect("Clap should've validated tool name");
-        log::debug!("Delegating to {} with {:?}", subcommand_name, sub_matches);
-        return tool_main(sub_matches);
+    // Only invoke tools if they come first, to avoid ambiguity with main binary
+
+    // .setting(AppSettings::ArgsNegateSubcommands)
+    // .version(VERSION)
+    // .get_matches();
+
+    // if let Some((subcommand_name, sub_matches)) = config.subcommand() {
+    //     let tool_main =
+    //         tools::get_tool_main(subcommand_name).expect("Clap should've validated tool name");
+    //     log::debug!("Delegating to {} with {:?}", subcommand_name, sub_matches);
+    //     return tool_main(sub_matches);
+    // }
+
+    // new:
+    let config = ClapApp::parse();
+
+    if let Some(subcommand) = config.subcommand {
+        return subcommand.invoke_main();
     }
 
     // If relative paths are specified, they should be resoled relative to the current directory
@@ -63,30 +221,27 @@ fn main() -> Result<()> {
     builder.set_cargo_integration(false);
 
     // NOTE: Grammar file is required option
-    let grammar_file = PathBuf::from(
-        config
-            .value_of("grammar")
-            .ok_or_else(|| miette!("Missing input grammar file (Specify with `-f`)"))?,
-    );
+    let grammar_file = config
+        .grammar
+        .as_ref()
+        .ok_or_else(|| miette!("Missing input grammar file (Specify with `-f`)"))?;
     builder.grammar_file(&grammar_file);
 
-    if let Some(max_k_str) = config.value_of("lookahead") {
-        builder.max_lookahead(max_k_str.parse::<usize>().into_diagnostic()?)?;
-    }
-    if let Some(module) = config.value_of("module") {
+    builder.max_lookahead(config.lookahead)?;
+    if let Some(module) = &config.module {
         builder.user_trait_module_name(module);
     }
-    if let Some(user_type) = config.value_of("user_type") {
+    if let Some(user_type) = &config.user_type {
         builder.user_type_name(user_type);
     }
-    if let Some(actions_file) = config.value_of("actions") {
+    if let Some(actions_file) = &config.actions {
         builder.actions_output_file(actions_file);
     }
-    if let Some(parser_file) = config.value_of("parser") {
+    if let Some(parser_file) = &config.parser {
         builder.parser_output_file(parser_file);
     }
-    if let Some(expanded_grammar_file) = config.value_of("expanded") {
-        if expanded_grammar_file == "--" {
+    if let Some(expanded_grammar_file) = &config.expanded {
+        if expanded_grammar_file == OsStr::new("--") {
             // We special case this in our listener (see below)
         } else {
             builder.expanded_grammar_output_file(expanded_grammar_file);
@@ -107,16 +262,16 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-pub struct CLIListener<'a, 'm> {
-    config: &'a clap::ArgMatches<'m>,
+pub struct CLIListener<'a> {
+    config: &'a ClapApp,
     grammar_file: &'a Path,
 }
-impl CLIListener<'_, '_> {
+impl CLIListener<'_> {
     fn verbose(&self) -> bool {
-        self.config.is_present("verbose")
+        self.config.verbose
     }
 }
-impl BuildListener for CLIListener<'_, '_> {
+impl BuildListener for CLIListener<'_> {
     fn on_initial_grammar_parse(
         &mut self,
         syntax_tree: &Tree<ParseTreeType>,
@@ -126,14 +281,14 @@ impl BuildListener for CLIListener<'_, '_> {
             println!("{}", parol_grammar);
         }
 
-        if let Some(file_name) = self.config.value_of("write_internal").as_ref() {
+        if let Some(file_name) = self.config.write_internal.as_ref() {
             let serialized = format!("{}", parol_grammar);
             fs::write(file_name, serialized)
                 .into_diagnostic()
                 .wrap_err("Error writing left-factored grammar!")?;
         }
 
-        if self.config.is_present("generate_tree_graph") {
+        if self.config.generate_tree_graph {
             parol::generate_tree_layout(syntax_tree, &self.grammar_file)
                 .wrap_err("Error generating tree layout")?;
         }
@@ -149,7 +304,7 @@ impl BuildListener for CLIListener<'_, '_> {
         match stage {
             // no passes yet
             IntermediateGrammar::Untransformed => {
-                if let Some(file_name) = self.config.value_of("write_untransformed") {
+                if let Some(file_name) = self.config.write_untransformed.as_ref() {
                     let serialized = render_par_string(grammar_config, false);
                     fs::write(file_name, serialized)
                         .into_diagnostic()
@@ -158,10 +313,10 @@ impl BuildListener for CLIListener<'_, '_> {
             }
             // final pass
             IntermediateGrammar::LAST => {
-                if let Some(file_name) = self.config.value_of("expanded").as_ref() {
+                if let Some(file_name) = self.config.expanded.as_ref() {
                     // NOTE: We still need special handling for writing to stdout
                     let lf_source = render_par_string(grammar_config, true);
-                    if *file_name == "--" {
+                    if *file_name == OsStr::new("--") {
                         print!("{}", lf_source);
                     } else {
                         // Should be handled by the builder

--- a/src/bin/parol/tools.rs
+++ b/src/bin/parol/tools.rs
@@ -1,25 +1,25 @@
 //! A registry for all the extra tools that can be used with parol.
 
-pub type SubCommandFunc = fn() -> clap::App<'static, 'static>;
+pub type SubCommandFunc = fn() -> clap::App<'static>;
 pub type ToolFunc = fn(&clap::ArgMatches) -> miette::Result<()>;
 
-pub fn get_tool_sub_command(name: &str) -> Option<SubCommandFunc> {
-    TOOLS
-        .iter()
-        .find(|(actual_name, _, _)| *actual_name == name)
-        .map(|tool| tool.1)
-}
+// pub fn get_tool_sub_command(name: &str) -> Option<SubCommandFunc> {
+//     TOOLS
+//         .iter()
+//         .find(|(actual_name, _, _)| *actual_name == name)
+//         .map(|tool| tool.1)
+// }
 
-pub fn get_tool_main(name: &str) -> Option<ToolFunc> {
-    TOOLS
-        .iter()
-        .find(|(actual_name, _, _)| *actual_name == name)
-        .map(|tool| tool.2)
-}
-
-pub fn names() -> impl Iterator<Item = &'static str> {
-    TOOLS.iter().map(|(name, _, _)| *name)
-}
+// pub fn get_tool_main(name: &str) -> Option<ToolFunc> {
+//     TOOLS
+//         .iter()
+//         .find(|(actual_name, _, _)| *actual_name == name)
+//         .map(|tool| tool.2)
+// }
+//
+// pub fn names() -> impl Iterator<Item = &'static str> {
+//     TOOLS.iter().map(|(name, _, _)| *name)
+// }
 
 /*
  * For each specified tool name this
@@ -30,9 +30,29 @@ pub fn names() -> impl Iterator<Item = &'static str> {
 macro_rules! declare_tools {
     ($($tool:ident),*) => {
         $(mod $tool;)*
-        pub static TOOLS: &[(&str, SubCommandFunc, ToolFunc)] = &[
-            $((stringify!($tool), self::$tool::sub_command, self::$tool::main)),*
-        ];
+        // pub static TOOLS: &[(&str, SubCommandFunc, ToolFunc)] = &[
+        //     $((stringify!($tool), self::$tool::sub_command, self::$tool::main)),*
+        // ];
+
+
+        #[derive(clap::Subcommand)]
+        pub enum ToolsSubcommands {
+            $(
+                $tool($tool ::Args),
+            )*
+        }
+
+        impl ToolsSubcommands {
+            pub fn invoke_main(&self) -> miette::Result<()> {
+                match self {
+                    $(
+                        ToolsSubcommands::$tool(args) => {
+                            self::$tool::main(args)
+                        }
+                    )*
+                }
+            }
+        }
     }
 }
 

--- a/src/bin/parol/tools/calculate_k.rs
+++ b/src/bin/parol/tools/calculate_k.rs
@@ -1,40 +1,46 @@
-use miette::{bail, IntoDiagnostic, Result, WrapErr};
+use miette::{bail, Result};
 use parol::analysis::k_decision::{calculate_k, FirstCache, FollowCache};
 use parol::{obtain_grammar_config, MAX_K};
+use std::path::PathBuf;
 
-pub fn sub_command() -> clap::App<'static, 'static> {
-    clap::SubCommand::with_name("calculate_k")
+/// Calculates the maximum lookahead needed for your grammar, similar to `decidable`.
+#[derive(clap::Parser)]
+#[clap(name = "calculate_k")]
+pub struct Args {
+    /// The grammar file to use
+    #[clap(short = 'f', long = "grammar-file", parse(from_os_str))]
+    grammar_file: PathBuf,
+    /// The maximum number of lookahead tokens to be used
+    #[clap(short = 'k', long = "lookahead", default_value = "5")]
+    lookahead: usize,
+}
+
+pub fn sub_command() -> clap::App<'static> {
+    clap::App::new("calculate_k")
         .about("Calculates the maximum lookahead needed for your grammar, similar to `decidable`.")
         .arg(
-            clap::Arg::with_name("grammar_file")
+            clap::Arg::new("grammar_file")
                 .required(true)
-                .short("f")
+                .short('f')
                 .long("grammar-file")
                 .takes_value(true)
-                .help("The grammar file to use")
+                .help("The grammar file to use"),
         )
         .arg(
-            clap::Arg::with_name("lookahead")
-                .short("k")
+            clap::Arg::new("lookahead")
+                .short('k')
                 .long("lookahead")
                 .takes_value(true)
                 .default_value("5")
-                .help("The maximum number of lookahead tokens to be used")
+                .help("The maximum number of lookahead tokens to be used"),
         )
 }
 
-pub fn main(args: &clap::ArgMatches) -> Result<()> {
-    let file_name = args
-        .value_of("grammar_file")
-        .unwrap();
+pub fn main(args: &Args) -> Result<()> {
+    let file_name = &args.grammar_file;
 
     let grammar_config = obtain_grammar_config(&file_name, true)?;
-    let max_k = args
-        .value_of("lookahead")
-        .unwrap()
-        .parse::<usize>()
-        .into_diagnostic()
-        .wrap_err("Provide a valid integer value for second argument")?;
+    let max_k = args.lookahead;
 
     if max_k > MAX_K {
         bail!("Maximum lookahead is {}", MAX_K);

--- a/src/bin/parol/tools/decidable.rs
+++ b/src/bin/parol/tools/decidable.rs
@@ -1,42 +1,48 @@
-use miette::{bail, IntoDiagnostic, Result, WrapErr};
+use miette::{bail, Result};
 use parol::analysis::{decidable, explain_conflicts, FirstCache, FollowCache};
 use parol::generators::generate_terminal_names;
 use parol::obtain_grammar_config;
 use parol::MAX_K;
+use std::path::PathBuf;
 
-pub fn sub_command() -> clap::App<'static, 'static> {
-    clap::SubCommand::with_name("decidable")
+/// Can be used to detect the maximum lookahead needed for your grammar.
+#[derive(clap::Parser)]
+#[clap(name = "decidable")]
+pub struct Args {
+    /// The grammar file to use
+    #[clap(short = 'f', long = "grammar-file", parse(from_os_str))]
+    grammar_file: PathBuf,
+    /// The maximum number of lookahead tokens to be used
+    #[clap(short = 'k', long = "lookahead", default_value = "5")]
+    lookahead: usize,
+}
+
+pub fn sub_command() -> clap::App<'static> {
+    clap::App::new("decidable")
         .about("Can be used to detect the maximum lookahead needed for your grammar.")
         .arg(
-            clap::Arg::with_name("grammar_file")
+            clap::Arg::new("grammar_file")
                 .required(true)
-                .short("f")
+                .short('f')
                 .long("grammar-file")
                 .takes_value(true)
-                .help("The grammar file to use")
+                .help("The grammar file to use"),
         )
         .arg(
-            clap::Arg::with_name("lookahead")
-                .short("k")
+            clap::Arg::new("lookahead")
+                .short('k')
                 .long("lookahead")
                 .takes_value(true)
                 .default_value("5")
-                .help("The maximum number of lookahead tokens to be used")
+                .help("The maximum number of lookahead tokens to be used"),
         )
 }
 
-pub fn main(args: &clap::ArgMatches) -> Result<()> {
-    let file_name = args
-        .value_of("grammar_file")
-        .unwrap();
+pub fn main(args: &Args) -> Result<()> {
+    let file_name = &args.grammar_file;
 
     let grammar_config = obtain_grammar_config(&file_name, false)?;
-    let max_k = args
-        .value_of("lookahead")
-        .unwrap()
-        .parse::<usize>()
-        .into_diagnostic()
-        .wrap_err("Provide a valid integer value for second argument")?;
+    let max_k = args.lookahead;
 
     if max_k > MAX_K {
         bail!("Maximum lookahead is {}", MAX_K);

--- a/src/bin/parol/tools/first.rs
+++ b/src/bin/parol/tools/first.rs
@@ -1,42 +1,48 @@
-use miette::{bail, IntoDiagnostic, Result, WrapErr};
+use miette::{bail, Result};
 use parol::analysis::{first_k, FirstCache};
 use parol::generators::generate_terminal_names;
 use parol::{obtain_grammar_config, KTuples, MAX_K};
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
-pub fn sub_command() -> clap::App<'static, 'static> {
-    clap::SubCommand::with_name("first")
+/// Calculates the FIRST(k) sets for each production and for each non-terminal.
+#[derive(clap::Parser)]
+#[clap(name = "first")]
+pub struct Args {
+    /// The grammar file to use
+    #[clap(short = 'f', long = "grammar-file", parse(from_os_str))]
+    grammar_file: PathBuf,
+    /// The maximum number of lookahead tokens to be used
+    #[clap(short = 'k', long = "lookahead", default_value = "1")]
+    lookahead: usize,
+}
+
+pub fn sub_command() -> clap::App<'static> {
+    clap::App::new("first")
         .about("Calculates the FIRST(k) sets for each production and for each non-terminal.")
         .arg(
-            clap::Arg::with_name("grammar_file")
+            clap::Arg::new("grammar_file")
                 .required(true)
-                .short("f")
+                .short('f')
                 .long("grammar-file")
                 .takes_value(true)
-                .help("The grammar file to use")
+                .help("The grammar file to use"),
         )
         .arg(
-            clap::Arg::with_name("lookahead")
-                .short("k")
+            clap::Arg::new("lookahead")
+                .short('k')
                 .long("lookahead")
                 .takes_value(true)
                 .default_value("1")
-                .help("The maximum number of lookahead tokens to be used")
+                .help("The maximum number of lookahead tokens to be used"),
         )
 }
 
-pub fn main(args: &clap::ArgMatches) -> Result<()> {
-    let file_name = args
-        .value_of("grammar_file")
-        .unwrap();
+pub fn main(args: &Args) -> Result<()> {
+    let file_name = &args.grammar_file;
 
     let grammar_config = obtain_grammar_config(&file_name, true)?;
-    let max_k = args
-        .value_of("lookahead")
-        .unwrap()
-        .parse::<usize>()
-        .into_diagnostic()
-        .wrap_err("Provide a valid integer value for second argument")?;
+    let max_k = args.lookahead;
 
     if max_k > MAX_K {
         bail!("Maximum lookahead is {}", MAX_K);

--- a/src/bin/parol/tools/follow.rs
+++ b/src/bin/parol/tools/follow.rs
@@ -1,42 +1,48 @@
-use miette::{bail, IntoDiagnostic, Result, WrapErr};
+use miette::{bail, Result};
 use parol::analysis::follow_k;
 use parol::analysis::FirstCache;
 use parol::generators::generate_terminal_names;
 use parol::{obtain_grammar_config, MAX_K};
+use std::path::PathBuf;
 
-pub fn sub_command() -> clap::App<'static, 'static> {
-    clap::SubCommand::with_name("follow")
+/// Calculates the FOLLOW(k) sets for each non-terminal.
+#[derive(clap::Parser)]
+#[clap(name = "follow")]
+pub struct Args {
+    /// The grammar file to use
+    #[clap(short = 'f', long = "grammar-file", parse(from_os_str))]
+    grammar_file: PathBuf,
+    /// The maximum number of lookahead tokens to be used
+    #[clap(short = 'k', long = "lookahead", default_value = "1")]
+    lookahead: usize,
+}
+
+pub fn sub_command() -> clap::App<'static> {
+    clap::App::new("follow")
         .about("Calculates the FOLLOW(k) sets for each non-terminal.")
         .arg(
-            clap::Arg::with_name("grammar_file")
+            clap::Arg::new("grammar_file")
                 .required(true)
-                .short("f")
+                .short('f')
                 .long("grammar-file")
                 .takes_value(true)
-                .help("The grammar file to use")
+                .help("The grammar file to use"),
         )
         .arg(
-            clap::Arg::with_name("lookahead")
-                .short("k")
+            clap::Arg::new("lookahead")
+                .short('k')
                 .long("lookahead")
                 .takes_value(true)
                 .default_value("1")
-                .help("The maximum number of lookahead tokens to be used")
+                .help("The maximum number of lookahead tokens to be used"),
         )
 }
 
-pub fn main(args: &clap::ArgMatches) -> Result<()> {
-    let file_name = args
-        .value_of("grammar_file")
-        .unwrap();
+pub fn main(args: &Args) -> Result<()> {
+    let file_name = &args.grammar_file;
 
     let grammar_config = obtain_grammar_config(&file_name, true)?;
-    let max_k = args
-        .value_of("lookahead")
-        .unwrap()
-        .parse::<usize>()
-        .into_diagnostic()
-        .wrap_err("Provide a valid integer value for second argument")?;
+    let max_k = args.lookahead;
 
     if max_k > MAX_K {
         bail!("Maximum lookahead is {}", MAX_K);

--- a/src/bin/parol/tools/format.rs
+++ b/src/bin/parol/tools/format.rs
@@ -1,27 +1,35 @@
 use miette::Result;
+use std::path::PathBuf;
 
 use parol::conversions::par::render_par_string;
 use parol::obtain_grammar_config;
 
-pub fn sub_command() -> clap::App<'static, 'static> {
-    clap::SubCommand::with_name("format")
+/// Formats the given grammar with the standard format and prints the result to stdout.
+#[derive(clap::Parser)]
+#[clap(name = "format")]
+pub struct Args {
+    /// The grammar file to use
+    #[clap(short = 'f', long = "grammar-file", parse(from_os_str))]
+    grammar_file: PathBuf,
+}
+
+pub fn sub_command() -> clap::App<'static> {
+    clap::App::new("format")
         .about(
             r"Formats the given grammar with the standard format and prints the result to stdout.",
         )
         .arg(
-            clap::Arg::with_name("grammar_file")
+            clap::Arg::new("grammar_file")
                 .required(true)
-                .short("f")
+                .short('f')
                 .long("grammar-file")
                 .takes_value(true)
-                .help("The grammar file to use")
+                .help("The grammar file to use"),
         )
 }
 
-pub fn main(args: &clap::ArgMatches) -> Result<()> {
-    let file_name = args
-        .value_of("grammar_file")
-        .unwrap();
+pub fn main(args: &Args) -> Result<()> {
+    let file_name = &args.grammar_file;
 
     let grammar_config = obtain_grammar_config(&file_name, false)?;
     println!("{}", render_par_string(&grammar_config, true));

--- a/src/bin/parol/tools/generate.rs
+++ b/src/bin/parol/tools/generate.rs
@@ -1,36 +1,45 @@
 use miette::Result;
 use parol::{obtain_grammar_config, LanguageGenerator};
+use std::path::PathBuf;
 
-pub fn sub_command() -> clap::App<'static, 'static> {
-    clap::SubCommand::with_name("generate")
+/// Generates a random sentence of the given grammar.
+/// It can be used to verify your language description.
+#[derive(clap::Parser)]
+#[clap(name = "generate")]
+pub struct Args {
+    /// The grammar file to use
+    #[clap(short = 'f', long = "grammar-file", parse(from_os_str))]
+    grammar_file: PathBuf,
+    /// The maximum length of generated sentence
+    #[clap(short = 'l', long = "max-length")]
+    max_len: Option<usize>,
+}
+
+pub fn sub_command() -> clap::App<'static> {
+    clap::App::new("generate")
         .about("Generates a random sentence of the given grammar. It can be used to verify your language description.")
         .arg(
-            clap::Arg::with_name("grammar_file")
+            clap::Arg::new("grammar_file")
                 .required(true)
-                .short("f")
+                .short('f')
                 .long("grammar-file")
                 .takes_value(true)
                 .help("The grammar file to use")
         )
         .arg(
-            clap::Arg::with_name("max_len")
-                .short("l")
+            clap::Arg::new("max_len")
+                .short('l')
                 .long("max-len")
                 .takes_value(true)
                 .help("The maximum length of generated sentence")
         )
 }
 
-pub fn main(args: &clap::ArgMatches) -> Result<()> {
-    let file_name = args
-        .value_of("grammar_file")
-        .unwrap();
+pub fn main(args: &Args) -> Result<()> {
+    let file_name = &args.grammar_file;
 
     let grammar_config = obtain_grammar_config(&file_name, false)?;
-    let max_sentence_length = args
-        .value_of("max-len")
-        .map(|v| v.parse::<usize>().ok())
-        .flatten();
+    let max_sentence_length = args.max_len;
     let mut generator = LanguageGenerator::new(&grammar_config.cfg);
     let result = generator.generate(max_sentence_length)?;
     println!("{}", result);

--- a/src/bin/parol/tools/left_factor.rs
+++ b/src/bin/parol/tools/left_factor.rs
@@ -1,24 +1,32 @@
 use miette::Result;
+use std::path::PathBuf;
 
 use parol::{left_factor, obtain_grammar_config};
 
-pub fn sub_command() -> clap::App<'static, 'static> {
-    clap::SubCommand::with_name("left_factor")
+/// Applies the left factoring algorithm on the grammar given.
+#[derive(clap::Parser)]
+#[clap(name = "left_factor")]
+pub struct Args {
+    /// The grammar file to use
+    #[clap(short = 'f', long = "grammar-file", parse(from_os_str))]
+    grammar_file: PathBuf,
+}
+
+pub fn sub_command() -> clap::App<'static> {
+    clap::App::new("left_factor")
         .about("Applies the left factoring algorithm on the grammar given.")
         .arg(
-            clap::Arg::with_name("grammar_file")
+            clap::Arg::new("grammar_file")
                 .required(true)
-                .short("f")
+                .short('f')
                 .long("grammar-file")
                 .takes_value(true)
-                .help("The grammar file to use")
+                .help("The grammar file to use"),
         )
 }
 
-pub fn main(args: &clap::ArgMatches) -> Result<()> {
-    let file_name = args
-        .value_of("grammar_file")
-        .unwrap();
+pub fn main(args: &Args) -> Result<()> {
+    let file_name = &args.grammar_file;
 
     let mut grammar_config = obtain_grammar_config(&file_name, false)?;
     let cfg = left_factor(&grammar_config.cfg);

--- a/src/bin/parol/tools/left_recursions.rs
+++ b/src/bin/parol/tools/left_recursions.rs
@@ -1,24 +1,32 @@
 use miette::Result;
+use std::path::PathBuf;
 
 use parol::{detect_left_recursions, obtain_grammar_config};
 
-pub fn sub_command() -> clap::App<'static, 'static> {
-    clap::SubCommand::with_name("left_recursion")
+/// Checks the given grammar for direct and indirect left recursions.
+#[derive(clap::Parser)]
+#[clap(name = "left_recursion")]
+pub struct Args {
+    /// The grammar file to use
+    #[clap(short = 'f', long = "grammar-file", parse(from_os_str))]
+    grammar_file: PathBuf,
+}
+
+pub fn sub_command() -> clap::App<'static> {
+    clap::App::new("left_recursion")
         .about("Checks the given grammar for direct and indirect left recursions.")
         .arg(
-            clap::Arg::with_name("grammar_file")
+            clap::Arg::new("grammar_file")
                 .required(true)
-                .short("f")
+                .short('f')
                 .long("grammar-file")
                 .takes_value(true)
-                .help("The grammar file to use")
+                .help("The grammar file to use"),
         )
 }
 
-pub fn main(args: &clap::ArgMatches) -> Result<()> {
-    let file_name = args
-        .value_of("grammar_file")
-        .unwrap();
+pub fn main(args: &Args) -> Result<()> {
+    let file_name = &args.grammar_file;
 
     let grammar_config = obtain_grammar_config(&file_name, false)?;
     let recursions = detect_left_recursions(&grammar_config.cfg);

--- a/src/bin/parol/tools/productivity.rs
+++ b/src/bin/parol/tools/productivity.rs
@@ -1,25 +1,31 @@
 use miette::Result;
+use std::path::PathBuf;
 
 use parol::analysis::non_productive_non_terminals;
 use parol::obtain_grammar_config;
 
-pub fn sub_command() -> clap::App<'static, 'static> {
-    clap::SubCommand::with_name("productivity")
+#[derive(clap::Parser)]
+pub struct Args {
+    /// The grammar file to use
+    #[clap(short = 'f', long = "grammar-file", parse(from_os_str))]
+    grammar_file: PathBuf,
+}
+
+pub fn sub_command() -> clap::App<'static> {
+    clap::App::new("productivity")
         .about("Checks the given grammar for non-productive non-terminals.")
         .arg(
-            clap::Arg::with_name("grammar_file")
+            clap::Arg::new("grammar_file")
                 .required(true)
-                .short("f")
+                .short('f')
                 .long("grammar-file")
                 .takes_value(true)
-                .help("The grammar file to use")
+                .help("The grammar file to use"),
         )
 }
 
-pub fn main(args: &clap::ArgMatches) -> Result<()> {
-    let file_name = args
-        .value_of("grammar_file")
-        .unwrap();
+pub fn main(args: &Args) -> Result<()> {
+    let file_name = &args.grammar_file;
 
     let grammar_config = obtain_grammar_config(&file_name, false)?;
 

--- a/src/bin/parol/tools/serialize.rs
+++ b/src/bin/parol/tools/serialize.rs
@@ -1,23 +1,31 @@
 use miette::Result;
 use parol::obtain_grammar_config;
+use std::path::PathBuf;
 
-pub fn sub_command() -> clap::App<'static, 'static> {
-    clap::SubCommand::with_name("serialize")
+/// Serializes a grammar to json format. Seldom to apply.
+#[derive(clap::Parser)]
+#[clap(name = "serialize")]
+pub struct Args {
+    /// The grammar file to use
+    #[clap(short = 'f', long = "grammar-file", parse(from_os_str))]
+    grammar_file: PathBuf,
+}
+
+pub fn sub_command() -> clap::App<'static> {
+    clap::App::new("serialize")
         .about("Serializes a grammar to json format. Seldom to apply.")
         .arg(
-            clap::Arg::with_name("grammar_file")
+            clap::Arg::new("grammar_file")
                 .required(true)
-                .short("f")
+                .short('f')
                 .long("grammar-file")
                 .takes_value(true)
-                .help("The grammar file to use")
+                .help("The grammar file to use"),
         )
 }
 
-pub fn main(args: &clap::ArgMatches) -> Result<()> {
-    let file_name = args
-        .value_of("grammar_file")
-        .unwrap();
+pub fn main(args: &Args) -> Result<()> {
+    let file_name = &args.grammar_file;
     let grammar_config = obtain_grammar_config(&file_name, false)?;
     let serialized = serde_json::to_string(&grammar_config).unwrap();
     println!("{}", serialized);


### PR DESCRIPTION
Hello. Thank you for this wonderful project!

I saw #10 and decided to give it a try.

I tried to leave most of the older code intact without changing too much, but it still became quite a big diff.

Changing from clap 2 to clap 3 involved pretty much:
- `App<'static, 'static>` -> `App<'static>`
- `App::with_name` / `Arg::with_name` -> `App::new` / `Arg::new`
- `Arg::short(&str)` -> `Arg::short(char)`

But there is also `clap_derive` (formerly [`structopt`](https://crates.io/crates/structopt)) that can simplify the code a lot.

Let me know what you think.