### PR TITLE
Add the link to PAR grammar in PAR

### DIFF
--- a/book/src/ParGrammar.md
+++ b/book/src/ParGrammar.md
@@ -1,6 +1,6 @@
 # The syntax of `parol`'s Grammar description
 
-Here I provide the definition of the PAR grammar in EBNF.
+Here I provide the definition of the PAR grammar in EBNF (PAR grammar in PAR is [here](https://github.com/jsinger67/parol/blob/main/src/parser/parol-grammar.par)).
 
 ```ebnf
 (* PAR Grammar defined in EBNF *)


### PR DESCRIPTION
It was very easy to understand the PAR grammar in EBNF. However, once I learned the grammar, referencing it in EBNF felt like noise. I think this will help people like me.