### PR TITLE
Remove boilerplates and fix bugs

### DIFF
--- a/src/bin/parol/tools/new.rs
+++ b/src/bin/parol/tools/new.rs
@@ -79,14 +79,7 @@ pub fn main(args: &Args) -> Result<()> {
 }
 
 const DEPENDENCIES: &[&[&str]] = &[
-    &["add", "derive_builder@0.11.2"],
     &["add", "env_logger@0.9.1"],
-    &["add", "function_name@0.3.0"],
-    &["add", "id_tree@1.8"],
-    &["add", "lazy_static@1.4"],
-    &["add", "log@0.4.17"],
-    &["add", "miette@5.2", "--features", "fancy"],
-    &["add", "parol-macros@0.1.0"],
     &["add", "parol_runtime@0.8.1"],
     &["add", "thiserror@1.0"],
     &[

--- a/src/bin/parol/tools/templates/grammar.rs.tpl
+++ b/src/bin/parol/tools/templates/grammar.rs.tpl
@@ -1,6 +1,6 @@
 use crate::{{crate_name}}_grammar_trait::{ {{grammar_name}}, {{grammar_name}}GrammarTrait};
 #[allow(unused_imports)]
-use miette::Result;
+use parol_runtime::miette::Result;
 use std::fmt::{Debug, Display, Error, Formatter};
 
 ///

--- a/src/bin/parol/tools/templates/lib.rs.tpl
+++ b/src/bin/parol/tools/templates/lib.rs.tpl
@@ -1,12 +1,5 @@
-#[macro_use]
-extern crate derive_builder;
-#[macro_use]
-extern crate function_name;
-#[macro_use]
-extern crate lazy_static;
-
-{{#tree_gen?}}use id_tree::Tree;
-use id_tree_layout::Layouter;
+{{#tree_gen?}}use parol_runtime::id_tree::Tree;
+use parol_runtime::id_tree_layout::Layouter;
 use parol_runtime::parser::ParseTreeType;{{/tree_gen}}
 
 extern crate parol_runtime;

--- a/src/bin/parol/tools/templates/main.rs.tpl
+++ b/src/bin/parol/tools/templates/main.rs.tpl
@@ -1,10 +1,3 @@
-#[macro_use]
-extern crate derive_builder;
-#[macro_use]
-extern crate function_name;
-#[macro_use]
-extern crate lazy_static;
-
 extern crate parol_runtime;
 
 mod {{crate_name}}_grammar;
@@ -14,10 +7,10 @@ mod {{crate_name}}_parser;
 
 use crate::{{crate_name}}_grammar::{{grammar_name}}Grammar;
 use crate::{{crate_name}}_parser::parse;{{#tree_gen?}}
-use id_tree::Tree;
-use id_tree_layout::Layouter;{{/tree_gen}}
-use log::debug;
-use miette::{miette, IntoDiagnostic, Result, WrapErr};{{#tree_gen?}}
+use parol_runtime::id_tree::Tree;
+use parol_runtime::id_tree_layout::Layouter;{{/tree_gen}}
+use parol_runtime::log::debug;
+use parol_runtime::miette::{miette, IntoDiagnostic, Result, WrapErr};{{#tree_gen?}}
 use parol_runtime::parser::ParseTreeType;{{/tree_gen}}
 use std::env;
 use std::fs;

--- a/src/generators/symbol_table.rs
+++ b/src/generators/symbol_table.rs
@@ -366,7 +366,8 @@ impl Instance {
         let desc = if self.description.is_empty() {
             String::default()
         } else {
-            format!("/* {} */", self.description)
+            // "*/" must be escaped
+            format!("/* {} */", self.description.replace("*/", "*\\/"))
         };
         format!(
             "{}: {}, {}",

--- a/templates/parser_template.rs.tpl
+++ b/templates/parser_template.rs.tpl
@@ -4,9 +4,9 @@
 // lost after next build.
 // ---------------------------------------------------------
 
-use id_tree::Tree;
+use parol_runtime::id_tree::Tree;
 use parol_runtime::lexer::{TokenStream, Tokenizer};
-use miette::Result;
+use parol_runtime::miette::Result;
 #[allow(unused_imports)]
 use parol_runtime::parser::{
     ParseTreeType, DFATransition, LLKParser, LookaheadDFA, ParseType, Production,{{^auto_generate?}} UserActionsTrait,{{/auto_generate}}
@@ -26,7 +26,7 @@ pub const NON_TERMINALS: &[&str; {{non_terminal_count}}] = &[
 
 {{{dfa_source}}}
 {{{productions}}}
-lazy_static! {
+parol_runtime::lazy_static::lazy_static! {
     static ref TOKENIZERS: Vec<(&'static str, Tokenizer)> = vec![
         ("INITIAL", Tokenizer::build(TERMINALS, SCANNER_0.0, SCANNER_0.1).unwrap()),
 {{{scanner_builds}}}

--- a/templates/user_trait_function_template.rs.tpl
+++ b/templates/user_trait_function_template.rs.tpl
@@ -2,7 +2,7 @@
     ///
     /// {{{prod_string}}}
     ///{{/inner}}{{#named?}}
-    #[named]{{/named}}
+    #[parol_runtime::function_name::named]{{/named}}
     fn {{fn_name}}(&mut self, {{{fn_arguments}}}) -> Result<()> {
         {{{code}}}Ok(())
     }

--- a/templates/user_trait_template.rs.tpl
+++ b/templates/user_trait_template.rs.tpl
@@ -4,15 +4,15 @@
 // lost after next build.
 // ---------------------------------------------------------
 
-{{#auto_generate?}}#![allow(unused_imports)]{{/auto_generate}}
-use id_tree::Tree;
-{{#auto_generate?}}use parol_macros::{pop_item, pop_and_reverse_item};{{/auto_generate}}
+use parol_runtime::id_tree::Tree;
+{{#auto_generate?}}use parol_runtime::parol_macros::{pop_item, pop_and_reverse_item};{{/auto_generate}}
 {{#auto_generate?}}use parol_runtime::lexer::Token;{{/auto_generate}}
 use parol_runtime::parser::{ParseTreeStackEntry, ParseTreeType, UserActionsTrait};
-{{#auto_generate?}}use log::trace;
-{{/auto_generate}}use miette::{miette, {{#auto_generate?}}bail, IntoDiagnostic, {{/auto_generate}}Result};
+{{#auto_generate?}}use parol_runtime::log::trace;
+{{/auto_generate}}use parol_runtime::miette::{miette, {{#auto_generate?}}bail, IntoDiagnostic, {{/auto_generate}}Result};
 use crate::{{module_name}}::{{user_type_name}};{{^ast_type_has_lifetime?}}
 use std::marker::PhantomData;{{/ast_type_has_lifetime}}
+use parol_runtime::derive_builder::Builder;
 
 {{#auto_generate?}}
 /// Semantic actions trait generated for the user grammar


### PR DESCRIPTION
Requires: https://github.com/jsinger67/parol_runtime/pull/2

I removed the boilerplates by using re-exports from `parol_runtime`.
Also, I fixed two bugs:
- parol generates a comment like `/* */ */` for token '*/', and this causes a compile error.
- `#![allow(unused_imports)]` generated by parol causes a compile error when using `import!()` macro. https://github.com/google/flatbuffers/issues/6261
