### PR TITLE
Add #[builder(crate = "parol_runtime::derive_builder")]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
 name = "basic"
 version = "0.5.0"
 dependencies = [
- "derive_builder 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_builder 0.11.2",
  "env_logger",
  "function_name",
  "id_tree",
@@ -232,15 +232,16 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
 dependencies = [
- "derive_builder_macro 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_builder_macro 0.11.2",
 ]
 
 [[package]]
 name = "derive_builder"
-version = "0.11.2"
-source = "git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field#c6211f8ea45e563716854f1cb39de431dd6a53a6"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
 dependencies = [
- "derive_builder_macro 0.11.2 (git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field)",
+ "derive_builder_macro 0.12.0",
 ]
 
 [[package]]
@@ -257,8 +258,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_core"
-version = "0.11.2"
-source = "git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field#c6211f8ea45e563716854f1cb39de431dd6a53a6"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -272,16 +274,17 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
- "derive_builder_core 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_builder_core 0.11.2",
  "syn 1.0.103",
 ]
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.11.2"
-source = "git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field#c6211f8ea45e563716854f1cb39de431dd6a53a6"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
- "derive_builder_core 0.11.2 (git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field)",
+ "derive_builder_core 0.12.0",
  "syn 1.0.103",
 ]
 
@@ -446,7 +449,7 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 name = "json_parser_auto"
 version = "0.4.0"
 dependencies = [
- "derive_builder 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_builder 0.11.2",
  "env_logger",
  "function_name",
  "id_tree",
@@ -635,13 +638,52 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parol"
+<<<<<<< HEAD
+=======
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f291d9271cd07f5a3627ec9dceca180f63cf4f25e90423d0aef3287d27e6b"
+dependencies = [
+ "bart 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bart_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "clap 3.2.23",
+ "derive_builder 0.11.2",
+ "env_logger",
+ "id_tree",
+ "id_tree_layout",
+ "lazy_static",
+ "log",
+ "miette 4.7.1",
+ "owo-colors",
+ "parol_runtime 0.5.9",
+ "petgraph",
+ "rand",
+ "rand_regex",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 1.0.103",
+ "thiserror",
+]
+
+[[package]]
+name = "parol"
+>>>>>>> c6f1ee2 (Use the latest derive_builder)
 version = "0.14.1-alpha.1"
 dependencies = [
  "bart",
  "bart_derive",
  "cfg-if",
+<<<<<<< HEAD
  "clap",
  "derive_builder 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+=======
+ "clap 4.0.26",
+ "derive_builder 0.11.2",
+>>>>>>> c6f1ee2 (Use the latest derive_builder)
  "env_logger",
  "function_name",
  "id_tree",
@@ -666,7 +708,7 @@ version = "0.3.4-alpha.1"
 dependencies = [
  "clap",
  "derive-new",
- "derive_builder 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_builder 0.11.2",
  "env_logger",
  "function_name",
  "id_tree",
@@ -692,7 +734,7 @@ version = "0.1.0"
 name = "parol_runtime"
 version = "0.10.0"
 dependencies = [
- "derive_builder 0.11.2 (git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field)",
+ "derive_builder 0.12.0",
  "function_name",
  "id_tree",
  "id_tree_layout",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
 name = "basic"
 version = "0.5.0"
 dependencies = [
- "derive_builder",
+ "derive_builder 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger",
  "function_name",
  "id_tree",
@@ -232,7 +232,15 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.11.2"
+source = "git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field#c6211f8ea45e563716854f1cb39de431dd6a53a6"
+dependencies = [
+ "derive_builder_macro 0.11.2 (git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field)",
 ]
 
 [[package]]
@@ -248,12 +256,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder_core"
+version = "0.11.2"
+source = "git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field#c6211f8ea45e563716854f1cb39de431dd6a53a6"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
+
+[[package]]
 name = "derive_builder_macro"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.11.2"
+source = "git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field#c6211f8ea45e563716854f1cb39de431dd6a53a6"
+dependencies = [
+ "derive_builder_core 0.11.2 (git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field)",
  "syn 1.0.103",
 ]
 
@@ -418,7 +446,7 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 name = "json_parser_auto"
 version = "0.4.0"
 dependencies = [
- "derive_builder",
+ "derive_builder 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger",
  "function_name",
  "id_tree",
@@ -567,7 +595,6 @@ dependencies = [
 name = "oberon2"
 version = "0.3.0"
 dependencies = [
- "derive_builder",
  "env_logger",
  "function_name",
  "id_tree",
@@ -614,7 +641,7 @@ dependencies = [
  "bart_derive",
  "cfg-if",
  "clap",
- "derive_builder",
+ "derive_builder 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger",
  "function_name",
  "id_tree",
@@ -639,7 +666,7 @@ version = "0.3.4-alpha.1"
 dependencies = [
  "clap",
  "derive-new",
- "derive_builder",
+ "derive_builder 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger",
  "function_name",
  "id_tree",
@@ -665,7 +692,7 @@ version = "0.1.0"
 name = "parol_runtime"
 version = "0.10.0"
 dependencies = [
- "derive_builder",
+ "derive_builder 0.11.2 (git+https://github.com/colin-kiegel/rust-derive-builder?branch=crate-field)",
  "function_name",
  "id_tree",
  "id_tree_layout",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,52 +638,13 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parol"
-<<<<<<< HEAD
-=======
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f291d9271cd07f5a3627ec9dceca180f63cf4f25e90423d0aef3287d27e6b"
-dependencies = [
- "bart 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bart_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if",
- "clap 3.2.23",
- "derive_builder 0.11.2",
- "env_logger",
- "id_tree",
- "id_tree_layout",
- "lazy_static",
- "log",
- "miette 4.7.1",
- "owo-colors",
- "parol_runtime 0.5.9",
- "petgraph",
- "rand",
- "rand_regex",
- "regex",
- "regex-syntax",
- "serde",
- "serde_derive",
- "serde_json",
- "syn 1.0.103",
- "thiserror",
-]
-
-[[package]]
-name = "parol"
->>>>>>> c6f1ee2 (Use the latest derive_builder)
 version = "0.14.1-alpha.1"
 dependencies = [
  "bart",
  "bart_derive",
  "cfg-if",
-<<<<<<< HEAD
  "clap",
- "derive_builder 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
-=======
- "clap 4.0.26",
  "derive_builder 0.11.2",
->>>>>>> c6f1ee2 (Use the latest derive_builder)
  "env_logger",
  "function_name",
  "id_tree",

--- a/crates/parol-ls/src/parol_ls_grammar_trait.rs
+++ b/crates/parol-ls/src/parol_ls_grammar_trait.rs
@@ -202,6 +202,7 @@ pub trait ParolLsGrammarTrait {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Declaration0 {
     pub percent_title: crate::parol_ls_grammar::OwnedToken, /* %title */
     pub string: Box<String>,
@@ -215,6 +216,7 @@ pub struct Declaration0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Declaration1 {
     pub percent_comment: crate::parol_ls_grammar::OwnedToken, /* %comment */
     pub string: Box<String>,
@@ -228,6 +230,7 @@ pub struct Declaration1 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Declaration2 {
     pub percent_user_underscore_type: crate::parol_ls_grammar::OwnedToken, /* %user_type */
     pub identifier: Box<Identifier>,
@@ -243,6 +246,7 @@ pub struct Declaration2 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Declaration3 {
     pub scanner_directives: Box<ScannerDirectives>,
 }
@@ -254,6 +258,7 @@ pub struct Declaration3 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ScannerDirectives0 {
     pub percent_line_underscore_comment: crate::parol_ls_grammar::OwnedToken, /* %line_comment */
     pub token_literal: Box<TokenLiteral>,
@@ -267,6 +272,7 @@ pub struct ScannerDirectives0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ScannerDirectives1 {
     pub percent_block_underscore_comment: crate::parol_ls_grammar::OwnedToken, /* %block_comment */
     pub token_literal: Box<TokenLiteral>,
@@ -281,6 +287,7 @@ pub struct ScannerDirectives1 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ScannerDirectives2 {
     pub percent_auto_underscore_newline_underscore_off: crate::parol_ls_grammar::OwnedToken, /* %auto_newline_off */
     pub comments: Box<Comments>,
@@ -293,6 +300,7 @@ pub struct ScannerDirectives2 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ScannerDirectives3 {
     pub percent_auto_underscore_ws_underscore_off: crate::parol_ls_grammar::OwnedToken, /* %auto_ws_off */
     pub comments: Box<Comments>,
@@ -305,6 +313,7 @@ pub struct ScannerDirectives3 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor0 {
     pub group: Box<Group>,
 }
@@ -316,6 +325,7 @@ pub struct Factor0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor1 {
     pub repeat: Box<Repeat>,
 }
@@ -327,6 +337,7 @@ pub struct Factor1 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor2 {
     pub optional: Box<Optional>,
 }
@@ -338,6 +349,7 @@ pub struct Factor2 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor3 {
     pub symbol: Box<Symbol>,
 }
@@ -349,6 +361,7 @@ pub struct Factor3 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Symbol0 {
     pub non_terminal: Box<NonTerminal>,
 }
@@ -360,6 +373,7 @@ pub struct Symbol0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Symbol1 {
     pub simple_token: Box<SimpleToken>,
 }
@@ -371,6 +385,7 @@ pub struct Symbol1 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Symbol2 {
     pub token_with_states: Box<TokenWithStates>,
 }
@@ -382,6 +397,7 @@ pub struct Symbol2 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Symbol3 {
     pub scanner_switch: Box<ScannerSwitch>,
 }
@@ -393,6 +409,7 @@ pub struct Symbol3 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TokenLiteral0 {
     pub string: Box<String>,
 }
@@ -404,6 +421,7 @@ pub struct TokenLiteral0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TokenLiteral1 {
     pub literal_string: Box<LiteralString>,
 }
@@ -415,6 +433,7 @@ pub struct TokenLiteral1 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TokenLiteral2 {
     pub regex: Box<Regex>,
 }
@@ -426,6 +445,7 @@ pub struct TokenLiteral2 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ScannerSwitch0 {
     pub percent_sc: crate::parol_ls_grammar::OwnedToken, /* %sc */
     pub l_paren: crate::parol_ls_grammar::OwnedToken,    /* \( */
@@ -440,6 +460,7 @@ pub struct ScannerSwitch0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ScannerSwitch1 {
     pub percent_push: crate::parol_ls_grammar::OwnedToken, /* %push */
     pub l_paren: crate::parol_ls_grammar::OwnedToken,      /* \( */
@@ -454,6 +475,7 @@ pub struct ScannerSwitch1 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ScannerSwitch2 {
     pub percent_pop: crate::parol_ls_grammar::OwnedToken, /* %pop */
     pub l_paren: crate::parol_ls_grammar::OwnedToken,     /* \( */
@@ -467,6 +489,7 @@ pub struct ScannerSwitch2 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ASTControl0 {
     pub cut_operator: Box<CutOperator>,
 }
@@ -478,6 +501,7 @@ pub struct ASTControl0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ASTControl1 {
     pub user_type_declaration: Box<UserTypeDeclaration>,
 }
@@ -489,6 +513,7 @@ pub struct ASTControl1 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct CommentsListGroup0 {
     pub line_comment: Box<LineComment>,
 }
@@ -500,6 +525,7 @@ pub struct CommentsListGroup0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct CommentsListGroup1 {
     pub block_comment: Box<BlockComment>,
 }
@@ -524,6 +550,7 @@ pub enum ASTControl {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Alternation {
     pub alternation_list: Vec<AlternationList>,
 }
@@ -533,6 +560,7 @@ pub struct Alternation {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct AlternationList {
     pub factor: Box<Factor>,
     pub comments: Box<Comments>,
@@ -543,6 +571,7 @@ pub struct AlternationList {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Alternations {
     pub alternation: Box<Alternation>,
     pub alternations_list: Vec<AlternationsList>,
@@ -553,6 +582,7 @@ pub struct Alternations {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct AlternationsList {
     pub or: crate::parol_ls_grammar::OwnedToken, /* \| */
     pub comments: Box<Comments>,
@@ -564,6 +594,7 @@ pub struct AlternationsList {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BlockComment {
     pub block_comment: crate::parol_ls_grammar::OwnedToken, /* (?ms)/\u{2a}.*?\u{2a}/ */
 }
@@ -573,6 +604,7 @@ pub struct BlockComment {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Comments {
     pub comments_list: Vec<CommentsList>,
 }
@@ -582,6 +614,7 @@ pub struct Comments {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct CommentsList {
     pub comments_list_group: Box<CommentsListGroup>,
 }
@@ -601,6 +634,7 @@ pub enum CommentsListGroup {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct CutOperator {
     pub cut_operator: crate::parol_ls_grammar::OwnedToken, /* \^ */
 }
@@ -622,6 +656,7 @@ pub enum Declaration {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DoubleColon {
     pub double_colon: crate::parol_ls_grammar::OwnedToken, /* :: */
 }
@@ -643,6 +678,7 @@ pub enum Factor {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct GrammarDefinition {
     pub percent_percent: crate::parol_ls_grammar::OwnedToken, /* %% */
     pub production: Box<Production>,
@@ -654,6 +690,7 @@ pub struct GrammarDefinition {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct GrammarDefinitionList {
     pub production: Box<Production>,
 }
@@ -663,6 +700,7 @@ pub struct GrammarDefinitionList {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Group {
     pub l_paren: crate::parol_ls_grammar::OwnedToken, /* \( */
     pub alternations: Box<Alternations>,
@@ -674,6 +712,7 @@ pub struct Group {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Identifier {
     pub identifier: crate::parol_ls_grammar::OwnedToken, /* [a-zA-Z_][a-zA-Z0-9_]* */
 }
@@ -683,6 +722,7 @@ pub struct Identifier {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LineComment {
     pub line_comment: crate::parol_ls_grammar::OwnedToken, /* //.*(:?\r\n|\r|\n|$) */
 }
@@ -692,6 +732,7 @@ pub struct LineComment {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LiteralString {
     pub literal_string: crate::parol_ls_grammar::OwnedToken, /* '(\\'|[^'])*?' */
 }
@@ -701,6 +742,7 @@ pub struct LiteralString {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct NonTerminal {
     pub identifier: Box<Identifier>,
     pub non_terminal_opt: Option<Box<NonTerminalOpt>>,
@@ -711,6 +753,7 @@ pub struct NonTerminal {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct NonTerminalOpt {
     pub a_s_t_control: Box<ASTControl>,
 }
@@ -720,6 +763,7 @@ pub struct NonTerminalOpt {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Optional {
     pub l_bracket: crate::parol_ls_grammar::OwnedToken, /* \[ */
     pub alternations: Box<Alternations>,
@@ -731,6 +775,7 @@ pub struct Optional {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ParolLs {
     pub prolog: Box<Prolog>,
     pub grammar_definition: Box<GrammarDefinition>,
@@ -741,6 +786,7 @@ pub struct ParolLs {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Production {
     pub production_l_h_s: Box<ProductionLHS>,
     pub alternations: Box<Alternations>,
@@ -752,6 +798,7 @@ pub struct Production {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ProductionLHS {
     pub comments: Box<Comments>,
     pub identifier: Box<Identifier>,
@@ -764,6 +811,7 @@ pub struct ProductionLHS {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Prolog {
     pub start_declaration: Box<StartDeclaration>,
     pub prolog_list: Vec<PrologList>,
@@ -775,6 +823,7 @@ pub struct Prolog {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct PrologList {
     pub declaration: Box<Declaration>,
 }
@@ -784,6 +833,7 @@ pub struct PrologList {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct PrologList0 {
     pub scanner_state: Box<ScannerState>,
 }
@@ -793,6 +843,7 @@ pub struct PrologList0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Regex {
     pub regex: crate::parol_ls_grammar::OwnedToken, /* /(\\/|[^/]|)*?/ */
 }
@@ -802,6 +853,7 @@ pub struct Regex {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Repeat {
     pub l_brace: crate::parol_ls_grammar::OwnedToken, /* \{ */
     pub alternations: Box<Alternations>,
@@ -825,6 +877,7 @@ pub enum ScannerDirectives {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ScannerState {
     pub percent_scanner: crate::parol_ls_grammar::OwnedToken, /* %scanner */
     pub identifier: Box<Identifier>,
@@ -838,6 +891,7 @@ pub struct ScannerState {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ScannerStateList {
     pub scanner_directives: Box<ScannerDirectives>,
 }
@@ -858,6 +912,7 @@ pub enum ScannerSwitch {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ScannerSwitchOpt {
     pub identifier: Box<Identifier>,
 }
@@ -867,6 +922,7 @@ pub struct ScannerSwitchOpt {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SimpleToken {
     pub token_literal: Box<TokenLiteral>,
     pub simple_token_opt: Option<Box<SimpleTokenOpt>>,
@@ -877,6 +933,7 @@ pub struct SimpleToken {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SimpleTokenOpt {
     pub a_s_t_control: Box<ASTControl>,
 }
@@ -886,6 +943,7 @@ pub struct SimpleTokenOpt {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StartDeclaration {
     pub comments: Box<Comments>,
     pub percent_start: crate::parol_ls_grammar::OwnedToken, /* %start */
@@ -898,6 +956,7 @@ pub struct StartDeclaration {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StateList {
     pub identifier: Box<Identifier>,
     pub state_list_list: Vec<StateListList>,
@@ -908,6 +967,7 @@ pub struct StateList {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StateListList {
     pub comma: crate::parol_ls_grammar::OwnedToken, /* , */
     pub identifier: Box<Identifier>,
@@ -918,6 +978,7 @@ pub struct StateListList {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct String {
     pub string: crate::parol_ls_grammar::OwnedToken, /* \u{22}(\\.|[^\\])*?\u{22} */
 }
@@ -950,6 +1011,7 @@ pub enum TokenLiteral {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TokenWithStates {
     pub l_t: crate::parol_ls_grammar::OwnedToken, /* < */
     pub state_list: Box<StateList>,
@@ -963,6 +1025,7 @@ pub struct TokenWithStates {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TokenWithStatesOpt {
     pub a_s_t_control: Box<ASTControl>,
 }
@@ -972,6 +1035,7 @@ pub struct TokenWithStatesOpt {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct UserTypeDeclaration {
     pub colon: crate::parol_ls_grammar::OwnedToken, /* : */
     pub user_type_name: Box<UserTypeName>,
@@ -982,6 +1046,7 @@ pub struct UserTypeDeclaration {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct UserTypeName {
     pub identifier: Box<Identifier>,
     pub user_type_name_list: Vec<UserTypeNameList>,
@@ -992,6 +1057,7 @@ pub struct UserTypeName {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct UserTypeNameList {
     pub double_colon: Box<DoubleColon>,
     pub identifier: Box<Identifier>,

--- a/crates/parol/src/bin/parol/tools/templates/lib.rs.tpl
+++ b/crates/parol/src/bin/parol/tools/templates/lib.rs.tpl
@@ -1,7 +1,3 @@
-// auto generation needs derive_builder
-mod derive_builder {
-    pub use parol_runtime::derive_builder::*;
-}
 {{#tree_gen?}}use parol_runtime::id_tree::Tree;
 use parol_runtime::id_tree_layout::Layouter;
 use parol_runtime::parser::ParseTreeType;{{/tree_gen}}

--- a/crates/parol/src/bin/parol/tools/templates/main.rs.tpl
+++ b/crates/parol/src/bin/parol/tools/templates/main.rs.tpl
@@ -1,10 +1,5 @@
 extern crate parol_runtime;
 
-// auto generation needs derive_builder
-mod derive_builder {
-    pub use parol_runtime::derive_builder::*;
-}
-
 mod {{crate_name}}_grammar;
 // The output is version controlled
 mod {{crate_name}}_grammar_trait;

--- a/crates/parol/templates/non_terminal_type_struct_template.rs.tpl
+++ b/crates/parol/templates/non_terminal_type_struct_template.rs.tpl
@@ -2,6 +2,7 @@
 /// {{{.}}}{{/comment}}
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct {{type_name}}{{{lifetime}}} {
 {{#members}}
   pub {{{.}}}{{/members}}}

--- a/crates/parol/templates/non_terminal_type_vec_template.rs.tpl
+++ b/crates/parol/templates/non_terminal_type_vec_template.rs.tpl
@@ -2,5 +2,6 @@
 /// {{{.}}}{{/comment}}
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct {{non_terminal}} {
     vec: Vec<{{{type_ref}}}{{{lifetime}}}>}

--- a/crates/parol_runtime/Cargo.toml
+++ b/crates/parol_runtime/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-derive_builder = { version = "0.11.2", optional = true }
+derive_builder = { git = "https://github.com/colin-kiegel/rust-derive-builder", branch = "crate-field", optional = true }
 function_name = "0.3.0"
 id_tree = "1.8"
 id_tree_layout = "2.0.3"

--- a/crates/parol_runtime/Cargo.toml
+++ b/crates/parol_runtime/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-derive_builder = { git = "https://github.com/colin-kiegel/rust-derive-builder", branch = "crate-field", optional = true }
+derive_builder = { version = "0.12.0", optional = true }
 function_name = "0.3.0"
 id_tree = "1.8"
 id_tree_layout = "2.0.3"

--- a/examples/basic_interpreter/src/basic_grammar_trait.rs
+++ b/examples/basic_interpreter/src/basic_grammar_trait.rs
@@ -250,6 +250,7 @@ pub trait BasicGrammarTrait<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Statement0<'t> {
     pub remark: Box<Remark<'t>>,
 }
@@ -261,6 +262,7 @@ pub struct Statement0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Statement1 {
     pub goto_statement: Box<GotoStatement>,
 }
@@ -272,6 +274,7 @@ pub struct Statement1 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Statement2<'t> {
     pub if_statement: Box<IfStatement<'t>>,
 }
@@ -283,6 +286,7 @@ pub struct Statement2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Statement3<'t> {
     pub assignment: Box<Assignment<'t>>,
 }
@@ -294,6 +298,7 @@ pub struct Statement3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Statement4<'t> {
     pub print_statement: Box<PrintStatement<'t>>,
 }
@@ -305,6 +310,7 @@ pub struct Statement4<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Statement5 {
     pub end_statement: Box<EndStatement>,
 }
@@ -316,6 +322,7 @@ pub struct Statement5 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct IfBody0<'t> {
     pub then: Box<Then>,
     pub statement: Box<Statement<'t>>,
@@ -328,6 +335,7 @@ pub struct IfBody0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct IfBody1 {
     pub goto: Box<Goto>,
     pub line_number: Box<LineNumber>,
@@ -340,6 +348,7 @@ pub struct IfBody1 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Number0 {
     pub float: Box<Float>,
 }
@@ -351,6 +360,7 @@ pub struct Number0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Number1 {
     pub integer: Box<Integer>,
 }
@@ -362,6 +372,7 @@ pub struct Number1 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Float0 {
     pub float1: Box<Float1>,
 }
@@ -373,6 +384,7 @@ pub struct Float0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Float3 {
     pub float2: Box<Float2>,
 }
@@ -384,6 +396,7 @@ pub struct Float3 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SummationListGroup0<'t> {
     pub plus: Box<Plus<'t>>,
 }
@@ -395,6 +408,7 @@ pub struct SummationListGroup0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SummationListGroup1<'t> {
     pub minus: Box<Minus<'t>>,
 }
@@ -406,6 +420,7 @@ pub struct SummationListGroup1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor0 {
     pub literal: Box<Literal>,
 }
@@ -417,6 +432,7 @@ pub struct Factor0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor1<'t> {
     pub variable: Box<Variable<'t>>,
 }
@@ -428,6 +444,7 @@ pub struct Factor1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor2<'t> {
     pub minus: Box<Minus<'t>>,
     pub factor: Box<Factor<'t>>,
@@ -440,6 +457,7 @@ pub struct Factor2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor3<'t> {
     pub l_paren: Box<LParen<'t>>,
     pub expression: Box<Expression<'t>>,
@@ -456,6 +474,7 @@ pub struct Factor3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct AssignOp {}
 
 ///
@@ -463,6 +482,7 @@ pub struct AssignOp {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Assignment<'t> {
     pub assignment_opt: Option<Box<AssignmentOpt>>,
     pub variable: Box<Variable<'t>>,
@@ -475,6 +495,7 @@ pub struct Assignment<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct AssignmentOpt {
     pub r#let: Box<Let>,
 }
@@ -484,6 +505,7 @@ pub struct AssignmentOpt {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Basic<'t> {
     pub basic_opt: Option<Box<BasicOpt>>,
     pub line: Box<Line<'t>>,
@@ -496,6 +518,7 @@ pub struct Basic<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BasicList<'t> {
     pub end_of_line: Box<EndOfLine>,
     pub line: Box<Line<'t>>,
@@ -506,6 +529,7 @@ pub struct BasicList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BasicOpt {
     pub end_of_line: Box<EndOfLine>,
 }
@@ -515,6 +539,7 @@ pub struct BasicOpt {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BasicOpt0 {
     pub end_of_line: Box<EndOfLine>,
 }
@@ -524,6 +549,7 @@ pub struct BasicOpt0 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Comment<'t> {
     pub comment: Token<'t>, /* [^\r\n]+ */
 }
@@ -533,6 +559,7 @@ pub struct Comment<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct End {}
 
 ///
@@ -540,6 +567,7 @@ pub struct End {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EndOfLine {}
 
 ///
@@ -547,6 +575,7 @@ pub struct EndOfLine {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EndStatement {
     pub end: Box<End>,
 }
@@ -556,6 +585,7 @@ pub struct EndStatement {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Expression<'t> {
     pub logical_or: Box<LogicalOr<'t>>,
 }
@@ -587,6 +617,7 @@ pub enum Float {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Float1 {
     pub float1: crate::basic_grammar::BasicNumber, /* (?:(?:[0-9] *)+)?\. *(?:(?:[0-9] *)+)? *(?:E *[-+]? *(?:[0-9] *)+)? */
 }
@@ -596,6 +627,7 @@ pub struct Float1 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Float2 {
     pub float2: crate::basic_grammar::BasicNumber, /* (?:[0-9] *)+E *[-+]? *(?:[0-9] *)+ */
 }
@@ -605,6 +637,7 @@ pub struct Float2 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Goto {}
 
 ///
@@ -612,6 +645,7 @@ pub struct Goto {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct GotoStatement {
     pub goto: Box<Goto>,
     pub line_number: Box<LineNumber>,
@@ -622,6 +656,7 @@ pub struct GotoStatement {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct If {}
 
 ///
@@ -639,6 +674,7 @@ pub enum IfBody<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct IfStatement<'t> {
     pub r#if: Box<If>,
     pub expression: Box<Expression<'t>>,
@@ -650,6 +686,7 @@ pub struct IfStatement<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Integer {
     pub integer: crate::basic_grammar::BasicNumber, /* (?:[0-9] *)+ */
 }
@@ -659,6 +696,7 @@ pub struct Integer {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LParen<'t> {
     pub l_paren: Token<'t>, /* ( */
 }
@@ -668,6 +706,7 @@ pub struct LParen<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Let {}
 
 ///
@@ -675,6 +714,7 @@ pub struct Let {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Line<'t> {
     pub line_number: Box<LineNumber>,
     pub statement: Box<Statement<'t>>,
@@ -686,6 +726,7 @@ pub struct Line<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LineList<'t> {
     pub statement: Box<Statement<'t>>,
 }
@@ -695,6 +736,7 @@ pub struct LineList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LineNumber {
     pub line_number: crate::basic_grammar::BasicLineNumber, /* [0 ]*[1-9] *(?:[0-9] *){1,4}|[0 ]+ */
 }
@@ -704,6 +746,7 @@ pub struct LineNumber {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Literal {
     pub number: Box<Number>,
 }
@@ -713,6 +756,7 @@ pub struct Literal {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LogicalAnd<'t> {
     pub logical_not: Box<LogicalNot<'t>>,
     pub logical_and_list: Vec<LogicalAndList<'t>>,
@@ -723,6 +767,7 @@ pub struct LogicalAnd<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LogicalAndList<'t> {
     pub logical_and_op: Box<LogicalAndOp<'t>>,
     pub logical_not: Box<LogicalNot<'t>>,
@@ -733,6 +778,7 @@ pub struct LogicalAndList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LogicalAndOp<'t> {
     pub logical_and_op: Token<'t>, /* AND */
 }
@@ -742,6 +788,7 @@ pub struct LogicalAndOp<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LogicalNot<'t> {
     pub logical_not_opt: Option<Box<LogicalNotOpt<'t>>>,
     pub relational: Box<Relational<'t>>,
@@ -752,6 +799,7 @@ pub struct LogicalNot<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LogicalNotOp<'t> {
     pub logical_not_op: Token<'t>, /* NOT */
 }
@@ -761,6 +809,7 @@ pub struct LogicalNotOp<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LogicalNotOpt<'t> {
     pub logical_not_op: Box<LogicalNotOp<'t>>,
 }
@@ -770,6 +819,7 @@ pub struct LogicalNotOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LogicalOr<'t> {
     pub logical_and: Box<LogicalAnd<'t>>,
     pub logical_or_list: Vec<LogicalOrList<'t>>,
@@ -780,6 +830,7 @@ pub struct LogicalOr<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LogicalOrList<'t> {
     pub logical_or_op: Box<LogicalOrOp<'t>>,
     pub logical_and: Box<LogicalAnd<'t>>,
@@ -790,6 +841,7 @@ pub struct LogicalOrList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LogicalOrOp<'t> {
     pub logical_or_op: Token<'t>, /* N?OR */
 }
@@ -799,6 +851,7 @@ pub struct LogicalOrOp<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Minus<'t> {
     pub minus: Token<'t>, /* - */
 }
@@ -808,6 +861,7 @@ pub struct Minus<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MulOp<'t> {
     pub mul_op: Token<'t>, /* \*|\u{2F} */
 }
@@ -817,6 +871,7 @@ pub struct MulOp<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Multiplication<'t> {
     pub factor: Box<Factor<'t>>,
     pub multiplication_list: Vec<MultiplicationList<'t>>,
@@ -827,6 +882,7 @@ pub struct Multiplication<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MultiplicationList<'t> {
     pub mul_op: Box<MulOp<'t>>,
     pub factor: Box<Factor<'t>>,
@@ -847,6 +903,7 @@ pub enum Number {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Plus<'t> {
     pub plus: Token<'t>, /* + */
 }
@@ -856,6 +913,7 @@ pub struct Plus<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Print {}
 
 ///
@@ -863,6 +921,7 @@ pub struct Print {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct PrintStatement<'t> {
     pub print: Box<Print>,
     pub expression: Box<Expression<'t>>,
@@ -874,6 +933,7 @@ pub struct PrintStatement<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct PrintStatementList<'t> {
     pub expression: Box<Expression<'t>>,
 }
@@ -883,6 +943,7 @@ pub struct PrintStatementList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct RParen<'t> {
     pub r_paren: Token<'t>, /* ) */
 }
@@ -892,6 +953,7 @@ pub struct RParen<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Relational<'t> {
     pub summation: Box<Summation<'t>>,
     pub relational_list: Vec<RelationalList<'t>>,
@@ -902,6 +964,7 @@ pub struct Relational<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct RelationalList<'t> {
     pub relational_op: Box<RelationalOp<'t>>,
     pub summation: Box<Summation<'t>>,
@@ -912,6 +975,7 @@ pub struct RelationalList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct RelationalOp<'t> {
     pub relational_op: Token<'t>, /* <\s*>|<\s*=|<|>\s*=|>|= */
 }
@@ -921,6 +985,7 @@ pub struct RelationalOp<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Remark<'t> {
     pub remark_opt: Option<Box<RemarkOpt<'t>>>,
 }
@@ -930,6 +995,7 @@ pub struct Remark<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct RemarkOpt<'t> {
     pub comment: Box<Comment<'t>>,
 }
@@ -953,6 +1019,7 @@ pub enum Statement<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Summation<'t> {
     pub multiplication: Box<Multiplication<'t>>,
     pub summation_list: Vec<SummationList<'t>>,
@@ -963,6 +1030,7 @@ pub struct Summation<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SummationList<'t> {
     pub summation_list_group: Box<SummationListGroup<'t>>,
     pub multiplication: Box<Multiplication<'t>>,
@@ -983,6 +1051,7 @@ pub enum SummationListGroup<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Then {}
 
 ///
@@ -990,6 +1059,7 @@ pub struct Then {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Variable<'t> {
     pub variable: Token<'t>, /* [A-Z][0-9A-Z]* */
 }

--- a/examples/json_parser_auto/src/json_grammar_trait.rs
+++ b/examples/json_parser_auto/src/json_grammar_trait.rs
@@ -65,6 +65,7 @@ pub trait JsonGrammarTrait<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ObjectSuffix0<'t> {
     pub pair: Box<Pair<'t>>,
     pub object_list: Vec<ObjectList<'t>>,
@@ -77,6 +78,7 @@ pub struct ObjectSuffix0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ObjectSuffix1 {}
 
 ///
@@ -86,6 +88,7 @@ pub struct ObjectSuffix1 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArraySuffix0<'t> {
     pub value: Box<Value<'t>>,
     pub array_list: Vec<ArrayList<'t>>,
@@ -98,6 +101,7 @@ pub struct ArraySuffix0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArraySuffix1 {}
 
 ///
@@ -107,6 +111,7 @@ pub struct ArraySuffix1 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Value0<'t> {
     pub string: Box<String<'t>>,
 }
@@ -118,6 +123,7 @@ pub struct Value0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Value1<'t> {
     pub number: Box<Number<'t>>,
 }
@@ -129,6 +135,7 @@ pub struct Value1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Value2<'t> {
     pub object: Box<Object<'t>>,
 }
@@ -140,6 +147,7 @@ pub struct Value2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Value3<'t> {
     pub array: Box<Array<'t>>,
 }
@@ -151,6 +159,7 @@ pub struct Value3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Value4 {}
 
 ///
@@ -160,6 +169,7 @@ pub struct Value4 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Value5 {}
 
 ///
@@ -169,6 +179,7 @@ pub struct Value5 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Value6 {}
 
 // -------------------------------------------------------------------------------------------------
@@ -181,6 +192,7 @@ pub struct Value6 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Array<'t> {
     pub array_suffix: Box<ArraySuffix<'t>>,
 }
@@ -190,6 +202,7 @@ pub struct Array<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayList<'t> {
     pub value: Box<Value<'t>>,
 }
@@ -209,6 +222,7 @@ pub enum ArraySuffix<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Json<'t> {
     pub value: Box<Value<'t>>,
 }
@@ -218,6 +232,7 @@ pub struct Json<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Number<'t> {
     pub number: Token<'t>, /* -?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][-+]?(?:0|[1-9][0-9]*)?)? */
 }
@@ -227,6 +242,7 @@ pub struct Number<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Object<'t> {
     pub object_suffix: Box<ObjectSuffix<'t>>,
 }
@@ -236,6 +252,7 @@ pub struct Object<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ObjectList<'t> {
     pub pair: Box<Pair<'t>>,
 }
@@ -255,6 +272,7 @@ pub enum ObjectSuffix<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Pair<'t> {
     pub string: Box<String<'t>>,
     pub value: Box<Value<'t>>,
@@ -265,6 +283,7 @@ pub struct Pair<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct String<'t> {
     pub string: Token<'t>, /* \u{0022}(?:\\[\u{0022}\\/bfnrt]|u[0-9a-fA-F]{4}|[^\u{0022}\\\u0000-\u001F])*\u{0022} */
 }

--- a/examples/oberon2/Cargo.toml
+++ b/examples/oberon2/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-derive_builder = "^0.11"
 env_logger = "0.9.0"
 function_name = "0.3.0"
 id_tree = "^1.8"

--- a/examples/oberon2/src/oberon2_grammar_trait.rs
+++ b/examples/oberon2/src/oberon2_grammar_trait.rs
@@ -395,6 +395,7 @@ pub trait Oberon2GrammarTrait<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DeclSeqList0Group0<'t> {
     pub proc_decl: Box<ProcDecl<'t>>,
 }
@@ -406,6 +407,7 @@ pub struct DeclSeqList0Group0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DeclSeqList0Group1<'t> {
     pub forward_decl: Box<ForwardDecl<'t>>,
 }
@@ -417,6 +419,7 @@ pub struct DeclSeqList0Group1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DeclBlock0<'t> {
     pub const_decl_block: Box<ConstDeclBlock<'t>>,
 }
@@ -428,6 +431,7 @@ pub struct DeclBlock0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DeclBlock1<'t> {
     pub type_decl_block: Box<TypeDeclBlock<'t>>,
 }
@@ -439,6 +443,7 @@ pub struct DeclBlock1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DeclBlock2<'t> {
     pub var_decl_block: Box<VarDeclBlock<'t>>,
 }
@@ -450,6 +455,7 @@ pub struct DeclBlock2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDef0<'t> {
     pub qual_ident: Box<QualIdent<'t>>,
 }
@@ -461,6 +467,7 @@ pub struct TypeDef0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDef1<'t> {
     pub type_def_opt: Option<Box<TypeDefOpt<'t>>>,
     pub type_def: Box<TypeDef<'t>>,
@@ -473,6 +480,7 @@ pub struct TypeDef1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDef2<'t> {
     pub type_def_opt0: Option<Box<TypeDefOpt0<'t>>>,
     pub field_list: Box<FieldList<'t>>,
@@ -486,6 +494,7 @@ pub struct TypeDef2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDef3<'t> {
     pub type_def: Box<TypeDef<'t>>,
 }
@@ -497,6 +506,7 @@ pub struct TypeDef3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDef4<'t> {
     pub type_def_opt1: Option<Box<TypeDefOpt1<'t>>>,
 }
@@ -508,6 +518,7 @@ pub struct TypeDef4<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroup0<'t> {
     pub designator: Box<Designator<'t>>,
     pub statement_opt_group_suffix: Box<StatementOptGroupSuffix<'t>>,
@@ -520,6 +531,7 @@ pub struct StatementOptGroup0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroupSuffix0<'t> {
     pub expr: Box<Expr<'t>>,
 }
@@ -531,6 +543,7 @@ pub struct StatementOptGroupSuffix0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroupSuffix1<'t> {
     pub statement_opt0: Option<Box<StatementOpt0<'t>>>,
 }
@@ -542,6 +555,7 @@ pub struct StatementOptGroupSuffix1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroup1<'t> {
     pub expr: Box<Expr<'t>>,
     pub then_block: Box<ThenBlock<'t>>,
@@ -556,6 +570,7 @@ pub struct StatementOptGroup1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroup2<'t> {
     pub expr: Box<Expr<'t>>,
     pub cases: Box<Cases<'t>>,
@@ -569,6 +584,7 @@ pub struct StatementOptGroup2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroup3<'t> {
     pub expr: Box<Expr<'t>>,
     pub do_block: Box<DoBlock<'t>>,
@@ -581,6 +597,7 @@ pub struct StatementOptGroup3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroup4<'t> {
     pub statement_seq: Box<StatementSeq<'t>>,
     pub expr: Box<Expr<'t>>,
@@ -593,6 +610,7 @@ pub struct StatementOptGroup4<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroup5<'t> {
     pub for_init: Box<ForInit<'t>>,
     pub statement_opt1: Option<Box<StatementOpt1<'t>>>,
@@ -606,6 +624,7 @@ pub struct StatementOptGroup5<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroup6<'t> {
     pub statement_seq: Box<StatementSeq<'t>>,
 }
@@ -617,6 +636,7 @@ pub struct StatementOptGroup6<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroup7<'t> {
     pub guarded_do_block: Box<GuardedDoBlock<'t>>,
     pub statement_opt_group_list0: Vec<StatementOptGroupList0<'t>>,
@@ -630,6 +650,7 @@ pub struct StatementOptGroup7<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroup8 {}
 
 ///
@@ -639,6 +660,7 @@ pub struct StatementOptGroup8 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroup9<'t> {
     pub statement_opt2: Option<Box<StatementOpt2<'t>>>,
 }
@@ -650,6 +672,7 @@ pub struct StatementOptGroup9<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SimpleExprOptGroup0<'t> {
     pub plus: Token<'t>, /* \+ */
 }
@@ -661,6 +684,7 @@ pub struct SimpleExprOptGroup0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SimpleExprOptGroup1<'t> {
     pub minus: Token<'t>, /* - */
 }
@@ -672,6 +696,7 @@ pub struct SimpleExprOptGroup1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor0<'t> {
     pub designator: Box<Designator<'t>>,
     pub factor_opt: Option<Box<FactorOpt<'t>>>,
@@ -684,6 +709,7 @@ pub struct Factor0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor1<'t> {
     pub number: Box<Number<'t>>,
 }
@@ -695,6 +721,7 @@ pub struct Factor1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor2<'t> {
     pub character: Box<Character<'t>>,
 }
@@ -706,6 +733,7 @@ pub struct Factor2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor3<'t> {
     pub string: Box<String<'t>>,
 }
@@ -717,6 +745,7 @@ pub struct Factor3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor4 {}
 
 ///
@@ -726,6 +755,7 @@ pub struct Factor4 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor5<'t> {
     pub set: Box<Set<'t>>,
 }
@@ -737,6 +767,7 @@ pub struct Factor5<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor6<'t> {
     pub expr: Box<Expr<'t>>,
 }
@@ -748,6 +779,7 @@ pub struct Factor6<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Factor7<'t> {
     pub factor: Box<Factor<'t>>,
 }
@@ -759,6 +791,7 @@ pub struct Factor7<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Relation0 {}
 
 ///
@@ -768,6 +801,7 @@ pub struct Relation0 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Relation1<'t> {
     pub hash: Token<'t>, /* # */
 }
@@ -779,6 +813,7 @@ pub struct Relation1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Relation2<'t> {
     pub l_t: Token<'t>, /* < */
 }
@@ -790,6 +825,7 @@ pub struct Relation2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Relation3<'t> {
     pub l_t_equ: Token<'t>, /* <= */
 }
@@ -801,6 +837,7 @@ pub struct Relation3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Relation4<'t> {
     pub g_t: Token<'t>, /* > */
 }
@@ -812,6 +849,7 @@ pub struct Relation4<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Relation5<'t> {
     pub g_t_equ: Token<'t>, /* >= */
 }
@@ -823,6 +861,7 @@ pub struct Relation5<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Relation6 {
     pub in_op: Box<InOp>,
 }
@@ -834,6 +873,7 @@ pub struct Relation6 {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Relation7<'t> {
     pub i_s: Token<'t>, /* IS */
 }
@@ -845,6 +885,7 @@ pub struct Relation7<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct AddOp0<'t> {
     pub plus: Token<'t>, /* \+ */
 }
@@ -856,6 +897,7 @@ pub struct AddOp0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct AddOp1<'t> {
     pub minus: Token<'t>, /* - */
 }
@@ -867,6 +909,7 @@ pub struct AddOp1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct AddOp2<'t> {
     pub o_r: Token<'t>, /* OR */
 }
@@ -878,6 +921,7 @@ pub struct AddOp2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MulOp0<'t> {
     pub star: Token<'t>, /* \* */
 }
@@ -889,6 +933,7 @@ pub struct MulOp0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MulOp1<'t> {
     pub slash: Token<'t>, /* / */
 }
@@ -900,6 +945,7 @@ pub struct MulOp1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MulOp2<'t> {
     pub d_i_v: Token<'t>, /* DIV */
 }
@@ -911,6 +957,7 @@ pub struct MulOp2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MulOp3<'t> {
     pub m_o_d: Token<'t>, /* MOD */
 }
@@ -922,6 +969,7 @@ pub struct MulOp3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MulOp4<'t> {
     pub amp: Token<'t>, /* & */
 }
@@ -933,6 +981,7 @@ pub struct MulOp4<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DesignatorSuffix0<'t> {
     pub ident: Box<Ident<'t>>,
 }
@@ -944,6 +993,7 @@ pub struct DesignatorSuffix0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DesignatorSuffix1<'t> {
     pub expr_list: Box<ExprList<'t>>,
 }
@@ -955,6 +1005,7 @@ pub struct DesignatorSuffix1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DesignatorSuffix2 {}
 
 ///
@@ -964,6 +1015,7 @@ pub struct DesignatorSuffix2 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct QualIdent0<'t> {
     pub ident: Box<Ident<'t>>,
 }
@@ -975,6 +1027,7 @@ pub struct QualIdent0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct QualIdent1<'t> {
     pub q_ident: Box<QIdent<'t>>,
 }
@@ -986,6 +1039,7 @@ pub struct QualIdent1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct IdentDefOptGroup0<'t> {
     pub star: Token<'t>, /* \* */
 }
@@ -997,6 +1051,7 @@ pub struct IdentDefOptGroup0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct IdentDefOptGroup1<'t> {
     pub minus: Token<'t>, /* - */
 }
@@ -1008,6 +1063,7 @@ pub struct IdentDefOptGroup1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Number0<'t> {
     pub integer: Box<Integer<'t>>,
 }
@@ -1019,6 +1075,7 @@ pub struct Number0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Number1<'t> {
     pub real: Box<Real<'t>>,
 }
@@ -1044,6 +1101,7 @@ pub enum AddOp<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Case<'t> {
     pub case_opt: Option<Box<CaseOpt<'t>>>,
 }
@@ -1053,6 +1111,7 @@ pub struct Case<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct CaseLabels<'t> {
     pub const_expr: Box<ConstExpr<'t>>,
     pub case_labels_opt: Option<Box<CaseLabelsOpt<'t>>>,
@@ -1063,6 +1122,7 @@ pub struct CaseLabels<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct CaseLabelsOpt<'t> {
     pub dot_dot: Token<'t>, /* \.\. */
     pub const_expr: Box<ConstExpr<'t>>,
@@ -1073,6 +1133,7 @@ pub struct CaseLabelsOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct CaseOpt<'t> {
     pub case_labels: Box<CaseLabels<'t>>,
     pub case_opt_list: Vec<CaseOptList<'t>>,
@@ -1084,6 +1145,7 @@ pub struct CaseOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct CaseOptList<'t> {
     pub case_labels: Box<CaseLabels<'t>>,
 }
@@ -1093,6 +1155,7 @@ pub struct CaseOptList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Cases<'t> {
     pub case: Box<Case<'t>>,
     pub cases_list: Vec<CasesList<'t>>,
@@ -1103,6 +1166,7 @@ pub struct Cases<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct CasesList<'t> {
     pub case: Box<Case<'t>>,
 }
@@ -1112,6 +1176,7 @@ pub struct CasesList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Character<'t> {
     pub character: Token<'t>, /* [0-9][0-9A-F]*X */
 }
@@ -1121,6 +1186,7 @@ pub struct Character<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ConstDecl<'t> {
     pub ident_def: Box<IdentDef<'t>>,
     pub const_expr: Box<ConstExpr<'t>>,
@@ -1131,6 +1197,7 @@ pub struct ConstDecl<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ConstDeclBlock<'t> {
     pub const_decl_block_list: Vec<ConstDeclBlockList<'t>>,
 }
@@ -1140,6 +1207,7 @@ pub struct ConstDeclBlock<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ConstDeclBlockList<'t> {
     pub const_decl: Box<ConstDecl<'t>>,
 }
@@ -1149,6 +1217,7 @@ pub struct ConstDeclBlockList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ConstExpr<'t> {
     pub expr: Box<Expr<'t>>,
 }
@@ -1169,6 +1238,7 @@ pub enum DeclBlock<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DeclSeq<'t> {
     pub decl_seq_list: Vec<DeclSeqList<'t>>,
     pub decl_seq_list0: Vec<DeclSeqList0<'t>>,
@@ -1179,6 +1249,7 @@ pub struct DeclSeq<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DeclSeqList<'t> {
     pub decl_block: Box<DeclBlock<'t>>,
 }
@@ -1188,6 +1259,7 @@ pub struct DeclSeqList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DeclSeqList0<'t> {
     pub decl_seq_list0_group: Box<DeclSeqList0Group<'t>>,
 }
@@ -1207,6 +1279,7 @@ pub enum DeclSeqList0Group<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Designator<'t> {
     pub qual_ident: Box<QualIdent<'t>>,
     pub designator_list: Vec<DesignatorList<'t>>,
@@ -1217,6 +1290,7 @@ pub struct Designator<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DesignatorList<'t> {
     pub designator_suffix: Box<DesignatorSuffix<'t>>,
 }
@@ -1237,6 +1311,7 @@ pub enum DesignatorSuffix<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DoBlock<'t> {
     pub statement_seq: Box<StatementSeq<'t>>,
 }
@@ -1246,6 +1321,7 @@ pub struct DoBlock<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Element<'t> {
     pub expr: Box<Expr<'t>>,
     pub element_opt: Option<Box<ElementOpt<'t>>>,
@@ -1256,6 +1332,7 @@ pub struct Element<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ElementOpt<'t> {
     pub expr: Box<Expr<'t>>,
 }
@@ -1265,6 +1342,7 @@ pub struct ElementOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ElsePart<'t> {
     pub statement_seq: Box<StatementSeq<'t>>,
 }
@@ -1274,6 +1352,7 @@ pub struct ElsePart<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ElsifPart<'t> {
     pub expr: Box<Expr<'t>>,
     pub then_block: Box<ThenBlock<'t>>,
@@ -1284,6 +1363,7 @@ pub struct ElsifPart<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Expr<'t> {
     pub simple_expr: Box<SimpleExpr<'t>>,
     pub expr_opt: Option<Box<ExprOpt<'t>>>,
@@ -1294,6 +1374,7 @@ pub struct Expr<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ExprList<'t> {
     pub expr: Box<Expr<'t>>,
     pub expr_list_list: Vec<ExprListList<'t>>,
@@ -1304,6 +1385,7 @@ pub struct ExprList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ExprListList<'t> {
     pub expr: Box<Expr<'t>>,
 }
@@ -1313,6 +1395,7 @@ pub struct ExprListList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ExprOpt<'t> {
     pub relation: Box<Relation<'t>>,
     pub simple_expr: Box<SimpleExpr<'t>>,
@@ -1323,6 +1406,7 @@ pub struct ExprOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct FPSection<'t> {
     pub f_p_section_opt: Option<Box<FPSectionOpt>>,
     pub ident: Box<Ident<'t>>,
@@ -1335,6 +1419,7 @@ pub struct FPSection<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct FPSectionList<'t> {
     pub ident: Box<Ident<'t>>,
 }
@@ -1344,6 +1429,7 @@ pub struct FPSectionList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct FPSectionOpt {}
 
 ///
@@ -1367,6 +1453,7 @@ pub enum Factor<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct FactorOpt<'t> {
     pub factor_opt0: Option<Box<FactorOpt0<'t>>>,
 }
@@ -1376,6 +1463,7 @@ pub struct FactorOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct FactorOpt0<'t> {
     pub expr_list: Box<ExprList<'t>>,
 }
@@ -1385,6 +1473,7 @@ pub struct FactorOpt0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct FieldList<'t> {
     pub field_list_opt: Option<Box<FieldListOpt<'t>>>,
 }
@@ -1394,6 +1483,7 @@ pub struct FieldList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct FieldListOpt<'t> {
     pub ident_list: Box<IdentList<'t>>,
     pub type_def: Box<TypeDef<'t>>,
@@ -1404,6 +1494,7 @@ pub struct FieldListOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ForInit<'t> {
     pub ident: Box<Ident<'t>>,
     pub expr: Box<Expr<'t>>,
@@ -1415,6 +1506,7 @@ pub struct ForInit<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ForStep<'t> {
     pub const_expr: Box<ConstExpr<'t>>,
 }
@@ -1424,6 +1516,7 @@ pub struct ForStep<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct FormalPars<'t> {
     pub formal_pars_opt: Option<Box<FormalParsOpt<'t>>>,
     pub formal_pars_opt0: Option<Box<FormalParsOpt0<'t>>>,
@@ -1434,6 +1527,7 @@ pub struct FormalPars<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct FormalParsOpt<'t> {
     pub f_p_section: Box<FPSection<'t>>,
     pub formal_pars_opt_list: Vec<FormalParsOptList<'t>>,
@@ -1444,6 +1538,7 @@ pub struct FormalParsOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct FormalParsOpt0<'t> {
     pub qual_ident: Box<QualIdent<'t>>,
 }
@@ -1453,6 +1548,7 @@ pub struct FormalParsOpt0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct FormalParsOptList<'t> {
     pub f_p_section: Box<FPSection<'t>>,
 }
@@ -1462,6 +1558,7 @@ pub struct FormalParsOptList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ForwardDecl<'t> {
     pub circumflex: Token<'t>, /* \^ */
     pub forward_decl_opt: Option<Box<ForwardDeclOpt<'t>>>,
@@ -1474,6 +1571,7 @@ pub struct ForwardDecl<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ForwardDeclOpt<'t> {
     pub receiver: Box<Receiver<'t>>,
 }
@@ -1483,6 +1581,7 @@ pub struct ForwardDeclOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ForwardDeclOpt0<'t> {
     pub formal_pars: Box<FormalPars<'t>>,
 }
@@ -1492,6 +1591,7 @@ pub struct ForwardDeclOpt0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Guard<'t> {
     pub qual_ident: Box<QualIdent<'t>>,
     pub qual_ident0: Box<QualIdent<'t>>,
@@ -1502,6 +1602,7 @@ pub struct Guard<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct GuardedDoBlock<'t> {
     pub guard: Box<Guard<'t>>,
     pub statement_seq: Box<StatementSeq<'t>>,
@@ -1512,6 +1613,7 @@ pub struct GuardedDoBlock<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Ident<'t> {
     pub ident: Token<'t>, /* [a-zA-Z_]\w* */
 }
@@ -1521,6 +1623,7 @@ pub struct Ident<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct IdentDef<'t> {
     pub ident: Box<Ident<'t>>,
     pub ident_def_opt: Option<Box<IdentDefOpt<'t>>>,
@@ -1531,6 +1634,7 @@ pub struct IdentDef<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct IdentDefOpt<'t> {
     pub ident_def_opt_group: Box<IdentDefOptGroup<'t>>,
 }
@@ -1550,6 +1654,7 @@ pub enum IdentDefOptGroup<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct IdentList<'t> {
     pub ident_def: Box<IdentDef<'t>>,
     pub ident_list_list: Vec<IdentListList<'t>>,
@@ -1560,6 +1665,7 @@ pub struct IdentList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct IdentListList<'t> {
     pub ident_def: Box<IdentDef<'t>>,
 }
@@ -1569,6 +1675,7 @@ pub struct IdentListList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ImportList<'t> {
     pub import_list_opt: Option<Box<ImportListOpt<'t>>>,
     pub ident: Box<Ident<'t>>,
@@ -1580,6 +1687,7 @@ pub struct ImportList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ImportListList<'t> {
     pub import_list_opt0: Option<Box<ImportListOpt0<'t>>>,
     pub ident: Box<Ident<'t>>,
@@ -1590,6 +1698,7 @@ pub struct ImportListList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ImportListOpt<'t> {
     pub ident: Box<Ident<'t>>,
 }
@@ -1599,6 +1708,7 @@ pub struct ImportListOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ImportListOpt0<'t> {
     pub ident: Box<Ident<'t>>,
 }
@@ -1608,6 +1718,7 @@ pub struct ImportListOpt0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct InOp {}
 
 ///
@@ -1615,6 +1726,7 @@ pub struct InOp {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Integer<'t> {
     pub integer: Token<'t>, /* [0-9][0-9]*|[0-9][0-9A-F]*H */
 }
@@ -1624,6 +1736,7 @@ pub struct Integer<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwBegin {}
 
 ///
@@ -1631,6 +1744,7 @@ pub struct KwBegin {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwCase {}
 
 ///
@@ -1638,6 +1752,7 @@ pub struct KwCase {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwDo {}
 
 ///
@@ -1645,6 +1760,7 @@ pub struct KwDo {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwElse {}
 
 ///
@@ -1652,6 +1768,7 @@ pub struct KwElse {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwElsif {}
 
 ///
@@ -1659,6 +1776,7 @@ pub struct KwElsif {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwEnd {}
 
 ///
@@ -1666,6 +1784,7 @@ pub struct KwEnd {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwIf {}
 
 ///
@@ -1673,6 +1792,7 @@ pub struct KwIf {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwOf {}
 
 ///
@@ -1680,6 +1800,7 @@ pub struct KwOf {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwProcedure {}
 
 ///
@@ -1687,6 +1808,7 @@ pub struct KwProcedure {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwThen {}
 
 ///
@@ -1694,6 +1816,7 @@ pub struct KwThen {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwTo {}
 
 ///
@@ -1701,6 +1824,7 @@ pub struct KwTo {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KwVar {}
 
 ///
@@ -1708,6 +1832,7 @@ pub struct KwVar {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ModuleBody<'t> {
     pub statement_block: Box<StatementBlock<'t>>,
 }
@@ -1717,6 +1842,7 @@ pub struct ModuleBody<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ModuleHead<'t> {
     pub ident: Box<Ident<'t>>,
 }
@@ -1749,6 +1875,7 @@ pub enum Number<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Oberon2<'t> {
     pub module_head: Box<ModuleHead<'t>>,
     pub oberon2_opt: Option<Box<Oberon2Opt<'t>>>,
@@ -1761,6 +1888,7 @@ pub struct Oberon2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Oberon2Opt<'t> {
     pub import_list: Box<ImportList<'t>>,
 }
@@ -1770,6 +1898,7 @@ pub struct Oberon2Opt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct OptElsePartEnd<'t> {
     pub opt_else_part_end_opt: Option<Box<OptElsePartEndOpt<'t>>>,
 }
@@ -1779,6 +1908,7 @@ pub struct OptElsePartEnd<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct OptElsePartEndOpt<'t> {
     pub else_part: Box<ElsePart<'t>>,
 }
@@ -1788,6 +1918,7 @@ pub struct OptElsePartEndOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ProcDecl<'t> {
     pub procedure_heading: Box<ProcedureHeading<'t>>,
     pub procedure_body: Box<ProcedureBody<'t>>,
@@ -1798,6 +1929,7 @@ pub struct ProcDecl<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ProcedureBody<'t> {
     pub decl_seq: Box<DeclSeq<'t>>,
     pub statement_block: Box<StatementBlock<'t>>,
@@ -1808,6 +1940,7 @@ pub struct ProcedureBody<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ProcedureHeading<'t> {
     pub procedure_heading_opt: Option<Box<ProcedureHeadingOpt<'t>>>,
     pub ident_def: Box<IdentDef<'t>>,
@@ -1819,6 +1952,7 @@ pub struct ProcedureHeading<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ProcedureHeadingOpt<'t> {
     pub receiver: Box<Receiver<'t>>,
 }
@@ -1828,6 +1962,7 @@ pub struct ProcedureHeadingOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ProcedureHeadingOpt0<'t> {
     pub formal_pars: Box<FormalPars<'t>>,
 }
@@ -1837,6 +1972,7 @@ pub struct ProcedureHeadingOpt0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct QIdent<'t> {
     pub q_ident: Token<'t>, /* [a-zA-Z_]\w*\.[a-zA-Z_]\w* */
 }
@@ -1856,6 +1992,7 @@ pub enum QualIdent<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Real<'t> {
     pub real: Token<'t>, /* [0-9][0-9]*\.[0-9]*(ED[+-]?[0-9][0-9]*)? */
 }
@@ -1865,6 +2002,7 @@ pub struct Real<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Receiver<'t> {
     pub receiver_opt: Option<Box<ReceiverOpt>>,
     pub receiver_var_decl: Box<ReceiverVarDecl<'t>>,
@@ -1875,6 +2013,7 @@ pub struct Receiver<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ReceiverOpt {}
 
 ///
@@ -1882,6 +2021,7 @@ pub struct ReceiverOpt {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ReceiverVarDecl<'t> {
     pub ident: Box<Ident<'t>>,
     pub ident0: Box<Ident<'t>>,
@@ -1908,6 +2048,7 @@ pub enum Relation<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Set<'t> {
     pub set_opt: Option<Box<SetOpt<'t>>>,
 }
@@ -1917,6 +2058,7 @@ pub struct Set<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SetOpt<'t> {
     pub element: Box<Element<'t>>,
     pub set_opt_list: Vec<SetOptList<'t>>,
@@ -1927,6 +2069,7 @@ pub struct SetOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SetOptList<'t> {
     pub element: Box<Element<'t>>,
 }
@@ -1936,6 +2079,7 @@ pub struct SetOptList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SimpleExpr<'t> {
     pub simple_expr_opt: Option<Box<SimpleExprOpt<'t>>>,
     pub term: Box<Term<'t>>,
@@ -1947,6 +2091,7 @@ pub struct SimpleExpr<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SimpleExprList<'t> {
     pub add_op: Box<AddOp<'t>>,
     pub term: Box<Term<'t>>,
@@ -1957,6 +2102,7 @@ pub struct SimpleExprList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SimpleExprOpt<'t> {
     pub simple_expr_opt_group: Box<SimpleExprOptGroup<'t>>,
 }
@@ -1976,6 +2122,7 @@ pub enum SimpleExprOptGroup<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Statement<'t> {
     pub statement_opt: Option<Box<StatementOpt<'t>>>,
 }
@@ -1985,6 +2132,7 @@ pub struct Statement<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementBlock<'t> {
     pub statement_block_opt: Option<Box<StatementBlockOpt<'t>>>,
     pub ident: Box<Ident<'t>>,
@@ -1995,6 +2143,7 @@ pub struct StatementBlock<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementBlockOpt<'t> {
     pub statement_seq: Box<StatementSeq<'t>>,
 }
@@ -2004,6 +2153,7 @@ pub struct StatementBlockOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOpt<'t> {
     pub statement_opt_group: Box<StatementOptGroup<'t>>,
 }
@@ -2013,6 +2163,7 @@ pub struct StatementOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOpt0<'t> {
     pub statement_opt3: Option<Box<StatementOpt3<'t>>>,
 }
@@ -2022,6 +2173,7 @@ pub struct StatementOpt0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOpt1<'t> {
     pub for_step: Box<ForStep<'t>>,
 }
@@ -2031,6 +2183,7 @@ pub struct StatementOpt1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOpt2<'t> {
     pub expr: Box<Expr<'t>>,
 }
@@ -2040,6 +2193,7 @@ pub struct StatementOpt2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOpt3<'t> {
     pub expr_list: Box<ExprList<'t>>,
 }
@@ -2067,6 +2221,7 @@ pub enum StatementOptGroup<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroupList<'t> {
     pub elsif_part: Box<ElsifPart<'t>>,
 }
@@ -2076,6 +2231,7 @@ pub struct StatementOptGroupList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementOptGroupList0<'t> {
     pub guarded_do_block: Box<GuardedDoBlock<'t>>,
 }
@@ -2095,6 +2251,7 @@ pub enum StatementOptGroupSuffix<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementSeq<'t> {
     pub statement: Box<Statement<'t>>,
     pub statement_seq_list: Vec<StatementSeqList<'t>>,
@@ -2105,6 +2262,7 @@ pub struct StatementSeq<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StatementSeqList<'t> {
     pub statement: Box<Statement<'t>>,
 }
@@ -2114,6 +2272,7 @@ pub struct StatementSeqList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct String<'t> {
     pub string: Token<'t>, /* \u{0022}[^\u{0022}]*\u{0022}|'[^']*' */
 }
@@ -2123,6 +2282,7 @@ pub struct String<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Term<'t> {
     pub factor: Box<Factor<'t>>,
     pub term_list: Vec<TermList<'t>>,
@@ -2133,6 +2293,7 @@ pub struct Term<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TermList<'t> {
     pub mul_op: Box<MulOp<'t>>,
     pub factor: Box<Factor<'t>>,
@@ -2143,6 +2304,7 @@ pub struct TermList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ThenBlock<'t> {
     pub statement_seq: Box<StatementSeq<'t>>,
 }
@@ -2152,6 +2314,7 @@ pub struct ThenBlock<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDecl<'t> {
     pub ident_def: Box<IdentDef<'t>>,
     pub type_def: Box<TypeDef<'t>>,
@@ -2162,6 +2325,7 @@ pub struct TypeDecl<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDeclBlock<'t> {
     pub type_decl_block_list: Vec<TypeDeclBlockList<'t>>,
 }
@@ -2171,6 +2335,7 @@ pub struct TypeDeclBlock<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDeclBlockList<'t> {
     pub type_decl: Box<TypeDecl<'t>>,
 }
@@ -2193,6 +2358,7 @@ pub enum TypeDef<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDefList<'t> {
     pub field_list: Box<FieldList<'t>>,
 }
@@ -2202,6 +2368,7 @@ pub struct TypeDefList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDefOpt<'t> {
     pub const_expr: Box<ConstExpr<'t>>,
     pub type_def_opt_list: Vec<TypeDefOptList<'t>>,
@@ -2212,6 +2379,7 @@ pub struct TypeDefOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDefOpt0<'t> {
     pub qual_ident: Box<QualIdent<'t>>,
 }
@@ -2221,6 +2389,7 @@ pub struct TypeDefOpt0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDefOpt1<'t> {
     pub formal_pars: Box<FormalPars<'t>>,
 }
@@ -2230,6 +2399,7 @@ pub struct TypeDefOpt1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct TypeDefOptList<'t> {
     pub const_expr: Box<ConstExpr<'t>>,
 }
@@ -2239,6 +2409,7 @@ pub struct TypeDefOptList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct VarDecl<'t> {
     pub ident_list: Box<IdentList<'t>>,
     pub type_def: Box<TypeDef<'t>>,
@@ -2249,6 +2420,7 @@ pub struct VarDecl<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct VarDeclBlock<'t> {
     pub var_decl_block_list: Vec<VarDeclBlockList<'t>>,
 }
@@ -2258,6 +2430,7 @@ pub struct VarDeclBlock<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct VarDeclBlockList<'t> {
     pub var_decl: Box<VarDecl<'t>>,
 }

--- a/examples/toml/Cargo.toml
+++ b/examples/toml/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
-derive_builder = "0.11.2"
 env_logger = "0.9.0"
 function_name = "0.3.0"
 id_tree = "1.8"

--- a/examples/toml/src/parol_toml_grammar_trait.rs
+++ b/examples/toml/src/parol_toml_grammar_trait.rs
@@ -465,6 +465,7 @@ pub trait ParolTomlGrammarTrait<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Expression0<'t> {
     pub key_val: Box<KeyVal<'t>>,
 }
@@ -476,6 +477,7 @@ pub struct Expression0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Expression1<'t> {
     pub table: Box<Table<'t>>,
 }
@@ -487,6 +489,7 @@ pub struct Expression1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KeySuffix0 {}
 
 ///
@@ -496,6 +499,7 @@ pub struct KeySuffix0 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KeySuffix1<'t> {
     pub dot_sep: Box<DotSep<'t>>,
     pub simple_key: Box<SimpleKey<'t>>,
@@ -509,6 +513,7 @@ pub struct KeySuffix1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SimpleKey0<'t> {
     pub quoted_key: Box<QuotedKey<'t>>,
 }
@@ -520,6 +525,7 @@ pub struct SimpleKey0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SimpleKey1<'t> {
     pub unquoted_key: Box<UnquotedKey<'t>>,
 }
@@ -531,6 +537,7 @@ pub struct SimpleKey1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct QuotedKey0<'t> {
     pub basic_string: Box<BasicString<'t>>,
 }
@@ -542,6 +549,7 @@ pub struct QuotedKey0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct QuotedKey1<'t> {
     pub literal_string: Box<LiteralString<'t>>,
 }
@@ -553,6 +561,7 @@ pub struct QuotedKey1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Val0<'t> {
     pub boolean: Box<Boolean<'t>>,
 }
@@ -564,6 +573,7 @@ pub struct Val0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Val1<'t> {
     pub array: Box<Array<'t>>,
 }
@@ -575,6 +585,7 @@ pub struct Val1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Val2<'t> {
     pub inline_table: Box<InlineTable<'t>>,
 }
@@ -586,6 +597,7 @@ pub struct Val2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Val3<'t> {
     pub date_time: Box<DateTime<'t>>,
 }
@@ -597,6 +609,7 @@ pub struct Val3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Val4<'t> {
     pub numeric: Box<Numeric<'t>>,
 }
@@ -608,6 +621,7 @@ pub struct Val4<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Val5<'t> {
     pub basic_string: Box<BasicString<'t>>,
 }
@@ -619,6 +633,7 @@ pub struct Val5<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Val6<'t> {
     pub m_l_basic_string: Box<MLBasicString<'t>>,
 }
@@ -630,6 +645,7 @@ pub struct Val6<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Val7<'t> {
     pub literal_string: Box<LiteralString<'t>>,
 }
@@ -641,6 +657,7 @@ pub struct Val7<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Val8<'t> {
     pub m_l_literal_string: Box<MLLiteralString<'t>>,
 }
@@ -652,6 +669,7 @@ pub struct Val8<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Numeric0<'t> {
     pub float: Box<Float<'t>>,
 }
@@ -663,6 +681,7 @@ pub struct Numeric0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Numeric1<'t> {
     pub integer: Box<Integer<'t>>,
 }
@@ -674,6 +693,7 @@ pub struct Numeric1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BasicChar0<'t> {
     pub basic_unescaped: Box<BasicUnescaped<'t>>,
 }
@@ -685,6 +705,7 @@ pub struct BasicChar0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BasicChar1<'t> {
     pub escaped: Box<Escaped<'t>>,
 }
@@ -696,6 +717,7 @@ pub struct BasicChar1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BasicUnescaped0<'t> {
     pub ascii_no_escape: Box<AsciiNoEscape<'t>>,
 }
@@ -707,6 +729,7 @@ pub struct BasicUnescaped0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BasicUnescaped1<'t> {
     pub non_ascii: Box<NonAscii<'t>>,
 }
@@ -718,6 +741,7 @@ pub struct BasicUnescaped1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EscapeSeqChar0<'t> {
     pub quotation_mark: Box<QuotationMark<'t>>,
 }
@@ -729,6 +753,7 @@ pub struct EscapeSeqChar0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EscapeSeqChar1<'t> {
     pub escape: Box<Escape<'t>>,
 }
@@ -740,6 +765,7 @@ pub struct EscapeSeqChar1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EscapeSeqChar2<'t> {
     pub b: Token<'t>, /* b */
 }
@@ -751,6 +777,7 @@ pub struct EscapeSeqChar2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EscapeSeqChar3<'t> {
     pub f: Token<'t>, /* f */
 }
@@ -762,6 +789,7 @@ pub struct EscapeSeqChar3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EscapeSeqChar4<'t> {
     pub n: Token<'t>, /* n */
 }
@@ -773,6 +801,7 @@ pub struct EscapeSeqChar4<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EscapeSeqChar5<'t> {
     pub r: Token<'t>, /* r */
 }
@@ -784,6 +813,7 @@ pub struct EscapeSeqChar5<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EscapeSeqChar6<'t> {
     pub t: Token<'t>, /* t */
 }
@@ -795,6 +825,7 @@ pub struct EscapeSeqChar6<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EscapeSeqChar7<'t> {
     pub unicode4: Box<Unicode4<'t>>,
 }
@@ -806,6 +837,7 @@ pub struct EscapeSeqChar7<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EscapeSeqChar8<'t> {
     pub unicode8: Box<Unicode8<'t>>,
 }
@@ -817,6 +849,7 @@ pub struct EscapeSeqChar8<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EscapeSeqChar9<'t> {
     pub ws_newline: Box<WsNewline<'t>>,
 }
@@ -828,6 +861,7 @@ pub struct EscapeSeqChar9<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct EscapeSeqChar10<'t> {
     pub ascii_no_escape: Box<AsciiNoEscape<'t>>,
 }
@@ -839,6 +873,7 @@ pub struct EscapeSeqChar10<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBContentList0<'t> {
     pub m_l_b_content: Box<MLBContent<'t>>,
     pub m_l_b_content_list: Box<MLBContentList<'t>>,
@@ -851,6 +886,7 @@ pub struct MLBContentList0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBContentList2 {}
 
 ///
@@ -860,6 +896,7 @@ pub struct MLBContentList2 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBContent0<'t> {
     pub m_l_b_char: Box<MLBChar<'t>>,
 }
@@ -871,6 +908,7 @@ pub struct MLBContent0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBContent1<'t> {
     pub newline: Box<Newline<'t>>,
 }
@@ -882,6 +920,7 @@ pub struct MLBContent1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBContent2<'t> {
     pub m_l_b_escaped_n_l: Box<MLBEscapedNL<'t>>,
 }
@@ -893,6 +932,7 @@ pub struct MLBContent2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBChar0<'t> {
     pub m_l_b_unescaped: Box<MLBUnescaped<'t>>,
 }
@@ -904,6 +944,7 @@ pub struct MLBChar0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBChar1<'t> {
     pub escaped: Box<Escaped<'t>>,
 }
@@ -915,6 +956,7 @@ pub struct MLBChar1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBUnescaped0<'t> {
     pub ascii_no_escape: Box<AsciiNoEscape<'t>>,
 }
@@ -926,6 +968,7 @@ pub struct MLBUnescaped0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBUnescaped1<'t> {
     pub non_ascii: Box<NonAscii<'t>>,
 }
@@ -937,6 +980,7 @@ pub struct MLBUnescaped1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LiteralChar0<'t> {
     pub literal_char_no_apostrophe: Box<LiteralCharNoApostrophe<'t>>,
 }
@@ -948,6 +992,7 @@ pub struct LiteralChar0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LiteralChar1<'t> {
     pub non_ascii: Box<NonAscii<'t>>,
 }
@@ -959,6 +1004,7 @@ pub struct LiteralChar1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLLContentList0<'t> {
     pub m_l_l_content: Box<MLLContent<'t>>,
     pub m_l_l_content_list: Box<MLLContentList<'t>>,
@@ -971,6 +1017,7 @@ pub struct MLLContentList0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLLContentList2 {}
 
 ///
@@ -980,6 +1027,7 @@ pub struct MLLContentList2 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLLContent0<'t> {
     pub literal_char: Box<LiteralChar<'t>>,
 }
@@ -991,6 +1039,7 @@ pub struct MLLContent0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLLContent1<'t> {
     pub newline: Box<Newline<'t>>,
 }
@@ -1002,6 +1051,7 @@ pub struct MLLContent1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Integer0<'t> {
     pub dec_int: Box<DecInt<'t>>,
 }
@@ -1013,6 +1063,7 @@ pub struct Integer0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Integer1<'t> {
     pub hex_int: Box<HexInt<'t>>,
 }
@@ -1024,6 +1075,7 @@ pub struct Integer1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Integer2<'t> {
     pub oct_int: Box<OctInt<'t>>,
 }
@@ -1035,6 +1087,7 @@ pub struct Integer2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Integer3<'t> {
     pub bin_int: Box<BinInt<'t>>,
 }
@@ -1046,6 +1099,7 @@ pub struct Integer3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DecIntOptGroup0<'t> {
     pub plus: Box<Plus<'t>>,
 }
@@ -1057,6 +1111,7 @@ pub struct DecIntOptGroup0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DecIntOptGroup1<'t> {
     pub minus: Box<Minus<'t>>,
 }
@@ -1068,6 +1123,7 @@ pub struct DecIntOptGroup1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Boolean0<'t> {
     pub r#true: Token<'t>, /* true */
 }
@@ -1079,6 +1135,7 @@ pub struct Boolean0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Boolean1<'t> {
     pub r#false: Token<'t>, /* false */
 }
@@ -1090,6 +1147,7 @@ pub struct Boolean1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Float0<'t> {
     pub normal_float: Box<NormalFloat<'t>>,
 }
@@ -1101,6 +1159,7 @@ pub struct Float0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Float1<'t> {
     pub special_float: Box<SpecialFloat<'t>>,
 }
@@ -1112,6 +1171,7 @@ pub struct Float1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DateTime0<'t> {
     pub offset_date_time: Box<OffsetDateTime<'t>>,
 }
@@ -1123,6 +1183,7 @@ pub struct DateTime0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DateTime1<'t> {
     pub local_date_time: Box<LocalDateTime<'t>>,
 }
@@ -1134,6 +1195,7 @@ pub struct DateTime1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DateTime2<'t> {
     pub local_date: Box<LocalDate<'t>>,
 }
@@ -1145,6 +1207,7 @@ pub struct DateTime2<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DateTime3<'t> {
     pub local_time: Box<LocalTime<'t>>,
 }
@@ -1156,6 +1219,7 @@ pub struct DateTime3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayValuesSuffix1<'t> {
     pub array_values_suffix: Box<ArrayValuesSuffix<'t>>,
 }
@@ -1167,6 +1231,7 @@ pub struct ArrayValuesSuffix1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayValuesSuffix2 {}
 
 ///
@@ -1176,6 +1241,7 @@ pub struct ArrayValuesSuffix2 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayValuesSuffix3<'t> {
     pub array_values: Box<ArrayValues<'t>>,
 }
@@ -1187,6 +1253,7 @@ pub struct ArrayValuesSuffix3<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayValuesSuffix4 {}
 
 ///
@@ -1196,6 +1263,7 @@ pub struct ArrayValuesSuffix4 {}
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Table0<'t> {
     pub std_table: Box<StdTable<'t>>,
 }
@@ -1207,6 +1275,7 @@ pub struct Table0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Table1<'t> {
     pub array_table: Box<ArrayTable<'t>>,
 }
@@ -1221,6 +1290,7 @@ pub struct Table1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Apostrophe<'t> {
     pub apostrophe: Token<'t>, /* \u{27} */
 }
@@ -1230,6 +1300,7 @@ pub struct Apostrophe<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Array<'t> {
     pub array_opt: Option<Box<ArrayOpt<'t>>>,
 }
@@ -1239,6 +1310,7 @@ pub struct Array<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayClose<'t> {
     pub array_close: Token<'t>, /* \u{5D} */
 }
@@ -1248,6 +1320,7 @@ pub struct ArrayClose<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayOpen<'t> {
     pub array_open: Token<'t>, /* \u{5B} */
 }
@@ -1257,6 +1330,7 @@ pub struct ArrayOpen<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayOpt<'t> {
     pub array_values: Box<ArrayValues<'t>>,
 }
@@ -1266,6 +1340,7 @@ pub struct ArrayOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArraySep<'t> {
     pub array_sep: Token<'t>, /* , */
 }
@@ -1275,6 +1350,7 @@ pub struct ArraySep<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayTable<'t> {
     pub key: Box<Key<'t>>,
 }
@@ -1284,6 +1360,7 @@ pub struct ArrayTable<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayTableClose<'t> {
     pub array_table_close: Token<'t>, /* \u{5D}\u{5D} */
 }
@@ -1293,6 +1370,7 @@ pub struct ArrayTableClose<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayTableOpen<'t> {
     pub array_table_open: Token<'t>, /* \u{5B}\u{5B} */
 }
@@ -1302,6 +1380,7 @@ pub struct ArrayTableOpen<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ArrayValues<'t> {
     pub val: Box<Val<'t>>,
     pub array_values_suffix0: Box<ArrayValuesSuffix0<'t>>,
@@ -1332,6 +1411,7 @@ pub enum ArrayValuesSuffix0<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct AsciiNoEscape<'t> {
     pub ascii_no_escape: Token<'t>, /* [ \t\u{21}\u{23}-\u{5B}\u{5D}-\u{7E}]+ */
 }
@@ -1351,6 +1431,7 @@ pub enum BasicChar<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BasicString<'t> {
     pub quotation_mark: Box<QuotationMark<'t>>,
     pub basic_string_list: Vec<BasicStringList<'t>>,
@@ -1362,6 +1443,7 @@ pub struct BasicString<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BasicStringList<'t> {
     pub basic_char: Box<BasicChar<'t>>,
 }
@@ -1381,6 +1463,7 @@ pub enum BasicUnescaped<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BinInt<'t> {
     pub bin_int_content: Box<BinIntContent<'t>>,
 }
@@ -1390,6 +1473,7 @@ pub struct BinInt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BinIntContent<'t> {
     pub bin_int_content: Token<'t>, /* [01]([01]|_[01])* */
 }
@@ -1399,6 +1483,7 @@ pub struct BinIntContent<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct BinPrefix<'t> {
     pub bin_prefix: Token<'t>, /* 0b */
 }
@@ -1430,6 +1515,7 @@ pub enum DateTime<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DecInt<'t> {
     pub dec_int_opt: Option<Box<DecIntOpt<'t>>>,
     pub unsigned_dec_int: Box<UnsignedDecInt<'t>>,
@@ -1440,6 +1526,7 @@ pub struct DecInt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DecIntOpt<'t> {
     pub dec_int_opt_group: Box<DecIntOptGroup<'t>>,
 }
@@ -1459,6 +1546,7 @@ pub enum DecIntOptGroup<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct DotSep<'t> {
     pub dot_sep: Token<'t>, /* \. */
 }
@@ -1468,6 +1556,7 @@ pub struct DotSep<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Escape<'t> {
     pub escape: Token<'t>, /* \u{5C} */
 }
@@ -1496,6 +1585,7 @@ pub enum EscapeSeqChar<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Escaped<'t> {
     pub escape: Box<Escape<'t>>,
     pub escape_seq_char: Box<EscapeSeqChar<'t>>,
@@ -1526,6 +1616,7 @@ pub enum Float<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct HexInt<'t> {
     pub hex_int_content: Box<HexIntContent<'t>>,
 }
@@ -1535,6 +1626,7 @@ pub struct HexInt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct HexIntContent<'t> {
     pub hex_int_content: Token<'t>, /* [0-9a-fA-F]([0-9a-fA-F]|_[0-9a-fA-F])* */
 }
@@ -1544,6 +1636,7 @@ pub struct HexIntContent<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct HexPrefix<'t> {
     pub hex_prefix: Token<'t>, /* 0x */
 }
@@ -1553,6 +1646,7 @@ pub struct HexPrefix<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct InlineTable<'t> {
     pub inline_table_opt: Option<Box<InlineTableOpt<'t>>>,
 }
@@ -1562,6 +1656,7 @@ pub struct InlineTable<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct InlineTableClose<'t> {
     pub inline_table_close: Token<'t>, /* \u{7D} */
 }
@@ -1571,6 +1666,7 @@ pub struct InlineTableClose<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct InlineTableKeyVals<'t> {
     pub key_val: Box<KeyVal<'t>>,
     pub inline_table_key_vals_opt: Option<Box<InlineTableKeyValsOpt<'t>>>,
@@ -1581,6 +1677,7 @@ pub struct InlineTableKeyVals<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct InlineTableKeyValsOpt<'t> {
     pub inline_table_key_vals: Box<InlineTableKeyVals<'t>>,
 }
@@ -1590,6 +1687,7 @@ pub struct InlineTableKeyValsOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct InlineTableOpen<'t> {
     pub inline_table_open: Token<'t>, /* \u{7B} */
 }
@@ -1599,6 +1697,7 @@ pub struct InlineTableOpen<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct InlineTableOpt<'t> {
     pub inline_table_key_vals: Box<InlineTableKeyVals<'t>>,
 }
@@ -1608,6 +1707,7 @@ pub struct InlineTableOpt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct InlineTableSep<'t> {
     pub array_sep: Box<ArraySep<'t>>,
 }
@@ -1629,6 +1729,7 @@ pub enum Integer<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Key<'t> {
     pub simple_key: Box<SimpleKey<'t>>,
     pub key_suffix: Box<KeySuffix<'t>>,
@@ -1639,6 +1740,7 @@ pub struct Key<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KeyList<'t> {
     pub dot_sep: Box<DotSep<'t>>,
     pub simple_key: Box<SimpleKey<'t>>,
@@ -1659,6 +1761,7 @@ pub enum KeySuffix<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KeyVal<'t> {
     pub key: Box<Key<'t>>,
     pub key_val_sep: Box<KeyValSep<'t>>,
@@ -1670,6 +1773,7 @@ pub struct KeyVal<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct KeyValSep<'t> {
     pub key_val_sep: Token<'t>, /* = */
 }
@@ -1689,6 +1793,7 @@ pub enum LiteralChar<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LiteralCharNoApostrophe<'t> {
     pub literal_char_no_apostrophe: Token<'t>, /* [\t\u{20}-\u{26}\u{28}-\u{7E}]+ */
 }
@@ -1698,6 +1803,7 @@ pub struct LiteralCharNoApostrophe<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LiteralString<'t> {
     pub literal_string_list: Vec<LiteralStringList<'t>>,
 }
@@ -1707,6 +1813,7 @@ pub struct LiteralString<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LiteralStringList<'t> {
     pub literal_char: Box<LiteralChar<'t>>,
 }
@@ -1716,6 +1823,7 @@ pub struct LiteralStringList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LocalDate<'t> {
     pub local_date: Token<'t>, /* [0-9]{4}-[0-9]{2}-[0-9]{2} */
 }
@@ -1725,6 +1833,7 @@ pub struct LocalDate<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LocalDateTime<'t> {
     pub local_date_time: Token<'t>, /* [0-9]{4}-[0-9]{2}-[0-9]{2}[Tt ][0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)? */
 }
@@ -1734,6 +1843,7 @@ pub struct LocalDateTime<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct LocalTime<'t> {
     pub local_time: Token<'t>, /* [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)? */
 }
@@ -1774,6 +1884,7 @@ pub enum MLBContentList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBContentList1<'t> {
     pub m_l_b_content: Box<MLBContent<'t>>,
     pub m_l_b_content_list: Box<MLBContentList<'t>>,
@@ -1784,6 +1895,7 @@ pub struct MLBContentList1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBEscapedNL<'t> {
     pub m_l_b_escaped_n_l: Token<'t>, /* \u{5C}[ \t]*\r?\n([ \t]|\r?\n)* */
 }
@@ -1793,6 +1905,7 @@ pub struct MLBEscapedNL<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBQuotes<'t> {
     pub m_l_b_quotes: Token<'t>, /* \u{22}{1,2} */
 }
@@ -1812,6 +1925,7 @@ pub enum MLBUnescaped<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBasicBody<'t> {
     pub m_l_b_content_list: Box<MLBContentList<'t>>,
     pub m_l_basic_body_list: Vec<MLBasicBodyList<'t>>,
@@ -1822,6 +1936,7 @@ pub struct MLBasicBody<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBasicBodyList<'t> {
     pub m_l_b_quotes: Box<MLBQuotes<'t>>,
     pub m_l_b_content_list1: Box<MLBContentList1<'t>>,
@@ -1832,6 +1947,7 @@ pub struct MLBasicBodyList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBasicString<'t> {
     pub m_l_basic_string_start: Box<MLBasicStringStart<'t>>,
     pub m_l_basic_body: Box<MLBasicBody<'t>>,
@@ -1843,6 +1959,7 @@ pub struct MLBasicString<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBasicStringEnd<'t> {
     pub m_l_basic_string_end: Token<'t>, /* \u{22}{3,5} */
 }
@@ -1852,6 +1969,7 @@ pub struct MLBasicStringEnd<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLBasicStringStart<'t> {
     pub m_l_basic_string_start: Token<'t>, /* \u{22}{3} */
 }
@@ -1881,6 +1999,7 @@ pub enum MLLContentList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLLContentList1<'t> {
     pub m_l_l_content: Box<MLLContent<'t>>,
     pub m_l_l_content_list: Box<MLLContentList<'t>>,
@@ -1891,6 +2010,7 @@ pub struct MLLContentList1<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLLQuotes<'t> {
     pub m_l_l_quotes: Token<'t>, /* \u{27}{1,2} */
 }
@@ -1900,6 +2020,7 @@ pub struct MLLQuotes<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLLiteralBody<'t> {
     pub m_l_l_content_list: Box<MLLContentList<'t>>,
     pub m_l_literal_body_list: Vec<MLLiteralBodyList<'t>>,
@@ -1910,6 +2031,7 @@ pub struct MLLiteralBody<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLLiteralBodyList<'t> {
     pub m_l_l_quotes: Box<MLLQuotes<'t>>,
     pub m_l_l_content_list1: Box<MLLContentList1<'t>>,
@@ -1920,6 +2042,7 @@ pub struct MLLiteralBodyList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLLiteralString<'t> {
     pub m_l_literal_body: Box<MLLiteralBody<'t>>,
 }
@@ -1929,6 +2052,7 @@ pub struct MLLiteralString<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLLiteralStringEnd<'t> {
     pub m_l_literal_string_end: Token<'t>, /* \u{27}{3,5}(?:\r?\n)? */
 }
@@ -1938,6 +2062,7 @@ pub struct MLLiteralStringEnd<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct MLLiteralStringStart<'t> {
     pub m_l_literal_string_start: Token<'t>, /* \u{27}{3} */
 }
@@ -1947,6 +2072,7 @@ pub struct MLLiteralStringStart<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Minus<'t> {
     pub minus: Token<'t>, /* \u{2D} */
 }
@@ -1956,6 +2082,7 @@ pub struct Minus<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Newline<'t> {
     pub newline: Token<'t>, /* \r?\n */
 }
@@ -1965,6 +2092,7 @@ pub struct Newline<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct NonAscii<'t> {
     pub non_ascii: Token<'t>, /* [\u{80}-\u{D7FF}\u{E000}-\u{10FFFF}] */
 }
@@ -1974,6 +2102,7 @@ pub struct NonAscii<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct NormalFloat<'t> {
     pub normal_float: Token<'t>, /* [-+]?(?:0|[1-9](?:[0-9]|_[0-9])*)(?:[eE][-+]?[0-9](?:[0-9]|_[0-9])*|(?:\.[0-9](?:[0-9]|_[0-9])*(?:[eE][-+]?[0-9](?:[0-9]|_[0-9])*)?)) */
 }
@@ -1993,6 +2122,7 @@ pub enum Numeric<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct OctInt<'t> {
     pub oct_int_content: Box<OctIntContent<'t>>,
 }
@@ -2002,6 +2132,7 @@ pub struct OctInt<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct OctIntContent<'t> {
     pub oct_int_content: Token<'t>, /* [0-7]([0-7]|_[0-7])* */
 }
@@ -2011,6 +2142,7 @@ pub struct OctIntContent<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct OctPrefix<'t> {
     pub oct_prefix: Token<'t>, /* 0o */
 }
@@ -2020,6 +2152,7 @@ pub struct OctPrefix<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct OffsetDateTime<'t> {
     pub offset_date_time: Token<'t>, /* [0-9]{4}-[0-9]{2}-[0-9]{2}[Tt ][0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?([Zz]|[-+][0-9]{2}:[0-9]{2}) */
 }
@@ -2029,6 +2162,7 @@ pub struct OffsetDateTime<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ParolToml<'t> {
     pub parol_toml_list: Vec<ParolTomlList<'t>>,
 }
@@ -2038,6 +2172,7 @@ pub struct ParolToml<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct ParolTomlList<'t> {
     pub expression: Box<Expression<'t>>,
 }
@@ -2047,6 +2182,7 @@ pub struct ParolTomlList<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Plus<'t> {
     pub plus: Token<'t>, /* \u{2B} */
 }
@@ -2056,6 +2192,7 @@ pub struct Plus<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct QuotationMark<'t> {
     pub quotation_mark: Token<'t>, /* \u{22} */
 }
@@ -2085,6 +2222,7 @@ pub enum SimpleKey<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct SpecialFloat<'t> {
     pub special_float: Token<'t>, /* [-+]?(nan|inf) */
 }
@@ -2094,6 +2232,7 @@ pub struct SpecialFloat<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StdTable<'t> {
     pub key: Box<Key<'t>>,
 }
@@ -2103,6 +2242,7 @@ pub struct StdTable<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StdTableClose<'t> {
     pub array_close: Box<ArrayClose<'t>>,
 }
@@ -2112,6 +2252,7 @@ pub struct StdTableClose<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct StdTableOpen<'t> {
     pub array_open: Box<ArrayOpen<'t>>,
 }
@@ -2131,6 +2272,7 @@ pub enum Table<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Unicode4<'t> {
     pub unicode4: Token<'t>, /* u[0-9a-fA-F]{4} */
 }
@@ -2140,6 +2282,7 @@ pub struct Unicode4<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct Unicode8<'t> {
     pub unicode8: Token<'t>, /* U[0-9a-fA-F]{8} */
 }
@@ -2149,6 +2292,7 @@ pub struct Unicode8<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct UnquotedKey<'t> {
     pub unquoted_key: Token<'t>, /* [-_A-Za-z0-9]+ */
 }
@@ -2158,6 +2302,7 @@ pub struct UnquotedKey<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct UnsignedDecInt<'t> {
     pub unsigned_dec_int: Token<'t>, /* 0|[1-9]([0-9]|_[0-9])* */
 }
@@ -2184,6 +2329,7 @@ pub enum Val<'t> {
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
+#[builder(crate = "parol_runtime::derive_builder")]
 pub struct WsNewline<'t> {
     pub ws_newline: Token<'t>, /* [ \t]*\r?\n */
 }


### PR DESCRIPTION
This is related to #23.
I've tried to extract boilerplates into `parol_runtime`, but we still need `pub use parol_runtime::derive_builder` in `lib.rs` or `main.rs` because `derive_builder` does not support re-exporting.
Now we can remove it, thanks to https://github.com/colin-kiegel/rust-derive-builder/pull/275.
This is a draft because it uses not released version of `derive_builder`.