### PR TITLE
Use \s for WHITESPACE_TOKEN

### DIFF
--- a/crates/parol_runtime/src/lexer/tokenizer.rs
+++ b/crates/parol_runtime/src/lexer/tokenizer.rs
@@ -20,7 +20,7 @@ pub const NEW_LINE_TOKEN: &str = r###"\r\n|\r|\n"###;
 ///
 /// Regular expression for any whitespace
 ///
-pub const WHITESPACE_TOKEN: &str = r###"[ \t]+"###;
+pub const WHITESPACE_TOKEN: &str = r###"\s+"###;
 
 ///
 /// Regular expression that matches any other token. With this you can detect


### PR DESCRIPTION
Current `WHITESPACE_TOKEN` does not cover all unicode whitespaces.