### PR TITLE
Add option `--stdio`

### DIFF
--- a/crates/parol-ls/src/arguments.rs
+++ b/crates/parol-ls/src/arguments.rs
@@ -7,11 +7,19 @@ use clap::Parser;
 #[clap(author, version, about)]
 pub struct Arguments {
     /// Server's IP address
-    #[clap(short = 'a', long = "address", default_value = "127.0.0.1")]
+    #[clap(
+        short = 'a',
+        long = "address",
+        group = "tcp",
+        default_value = "127.0.0.1"
+    )]
     pub ip_address: IpAddr,
     /// Server's port
-    #[clap(short = 's', long = "socket", default_value = "7061")]
+    #[clap(short = 's', long = "socket", group = "tcp", default_value = "7061")]
     pub port_number: u16,
+    /// Use stdio
+    #[clap(long = "stdio", conflicts_with = "tcp")]
+    pub stdio: bool,
     /// Lookahead limit
     #[clap(short = 'k', long = "lookahead", default_value = "3")]
     pub lookahead: usize,

--- a/crates/parol-ls/src/main.rs
+++ b/crates/parol-ls/src/main.rs
@@ -97,7 +97,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let args = Arguments::parse();
     eprintln!("Starting parol language server");
-    let (connection, io_threads) = Connection::connect((args.ip_address, args.port_number))?;
+
+    let (connection, io_threads) = if args.stdio {
+        Connection::stdio()
+    } else {
+        Connection::connect((args.ip_address, args.port_number))?
+    };
     let connection = Arc::new(connection);
 
     // Run the server and wait for the two threads to end (typically by trigger LSP Exit event).


### PR DESCRIPTION
This pull request adds `--stdio` option to `parol-ls` to start the language server on stdio.

It's useful when setting up editors such as Vim, Neovim and Helix for writing Parol.