### PR TITLE
Add #![allow(clippy::too_many_arguments)] to template_data.rs.

### DIFF
--- a/crates/parol-ls/src/parol_ls_grammar_trait.rs
+++ b/crates/parol-ls/src/parol_ls_grammar_trait.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::enum_variant_names)]
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::too_many_arguments)]
 
 use parol_runtime::derive_builder::Builder;
 use parol_runtime::log::trace;

--- a/crates/parol/src/generators/template_data.rs
+++ b/crates/parol/src/generators/template_data.rs
@@ -156,6 +156,7 @@ impl std::fmt::Display for UserTraitData<'_> {
             #![allow(clippy::enum_variant_names)]
             #![allow(clippy::large_enum_variant)]
             #![allow(clippy::upper_case_acronyms)]
+            #![allow(clippy::too_many_arguments)]
         })?;
 
         writeln!(f, "\n")?;

--- a/examples/basic_interpreter/src/basic_grammar_trait.rs
+++ b/examples/basic_interpreter/src/basic_grammar_trait.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::enum_variant_names)]
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::too_many_arguments)]
 
 use parol_runtime::derive_builder::Builder;
 use parol_runtime::log::trace;

--- a/examples/json_parser/src/json_grammar_trait.rs
+++ b/examples/json_parser/src/json_grammar_trait.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::enum_variant_names)]
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::too_many_arguments)]
 
 use crate::json_grammar::JsonGrammar;
 use parol_runtime::parser::{ParseTreeType, UserActionsTrait};

--- a/examples/json_parser_auto/src/json_grammar_trait.rs
+++ b/examples/json_parser_auto/src/json_grammar_trait.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::enum_variant_names)]
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::too_many_arguments)]
 
 use parol_runtime::derive_builder::Builder;
 use parol_runtime::log::trace;

--- a/examples/oberon2/src/oberon2_grammar_trait.rs
+++ b/examples/oberon2/src/oberon2_grammar_trait.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::enum_variant_names)]
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::too_many_arguments)]
 
 use parol_runtime::derive_builder::Builder;
 use parol_runtime::log::trace;

--- a/examples/toml/src/parol_toml_grammar_trait.rs
+++ b/examples/toml/src/parol_toml_grammar_trait.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::enum_variant_names)]
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::too_many_arguments)]
 
 use parol_runtime::derive_builder::Builder;
 use parol_runtime::log::trace;


### PR DESCRIPTION
Recently I had following clippy warnings for generated grammar trait.  Here is a patch to suppress the warning.

```
$ ~/rust/libyang main* cargo clippy
warning: this function has too many arguments (10/7)
    --> src/yang_grammar_trait.rs:7844:5
     |
7844 | /     fn module_stmt(
7845 | |         &mut self,
7846 | |         _module: &ParseTreeType<'t>,
7847 | |         _identifier_arg_str: &ParseTreeType<'t>,
...    |
7854 | |         _r_brace: &ParseTreeType<'t>,
7855 | |     ) -> Result<()> {
     | |___________________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
     = note: `#[warn(clippy::too_many_arguments)]` on by default

warning: this function has too many arguments (10/7)
    --> src/yang_grammar_trait.rs:8068:5
     |
8068 | /     fn submodule_stmt(
8069 | |         &mut self,
8070 | |         _submodule: &ParseTreeType<'t>,
8071 | |         _identifier_arg_str: &ParseTreeType<'t>,
...    |
8078 | |         _r_brace: &ParseTreeType<'t>,
8079 | |     ) -> Result<()> {
     | |___________________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments

warning: `libyang` (lib) generated 2 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s

```