### PR TITLE
Add API to access internal Vec of TokenVec

### DIFF
--- a/crates/parol_runtime/src/errors/types.rs
+++ b/crates/parol_runtime/src/errors/types.rs
@@ -116,12 +116,24 @@ impl Display for UnexpectedToken {
     }
 }
 
+/// A vector of tokens in a string representation
 #[derive(Debug, Default)]
 pub struct TokenVec(Vec<String>);
 
 impl TokenVec {
+    /// Pushes a token to the vector
     pub fn push(&mut self, token: String) {
         self.0.push(token);
+    }
+
+    /// Returns an iterator over the tokens
+    pub fn iter(&self) -> std::slice::Iter<String> {
+        self.0.iter()
+    }
+
+    /// Returns a token at the given index
+    pub fn get(&self, index: usize) -> Option<&String> {
+        self.0.get(index)
     }
 }
 


### PR DESCRIPTION
This pull request adds tow new methods to the TokenVec struct: `iter()` and `get()`. The `iter()` method returns an iterator over the tokens and `get()` method returns a token at the given index, These methods provide access to the internal Vec of TokenVec, allowing users to handle `expected_tokens` of `SyntaxError` as desired. Fixes #310