### PR TITLE
Use `inner_name()` for variant names in range generation

### DIFF
--- a/crates/parol/src/generators/symbol_table_facade.rs
+++ b/crates/parol/src/generators/symbol_table_facade.rs
@@ -267,7 +267,7 @@ impl<'a> TypeFacade<'a> for TypeItem<'a> {
                                     acc.push(format!(
                                         "{}::{}(v) => v.first().map_or(Span::default(), |f| f.span())",
                                         self.name(),
-                                        v.name()
+                                        v.inner_name()
                                     ));
                                     acc.push(
                                         "+ v.last().map_or(Span::default(), |l| l.span()),".to_string(),
@@ -276,11 +276,11 @@ impl<'a> TypeFacade<'a> for TypeItem<'a> {
                                 TypeEntrails::Option(_) => acc.push(format!(
                                     "{}::{}(o) => o.as_ref().map_or(Span::default(), |o| o.span()),",
                                     self.name(),
-                                    v.name()
+                                    v.inner_name()
                                 )),
                                 _ => {
                                     // Expr::CommentExpr(v) => v.span(),
-                                    acc.push(format!("{}::{}(v) => v.span(),", self.name(), v.name()))
+                                    acc.push(format!("{}::{}(v) => v.span(),", self.name(), v.inner_name()))
                                 }
                             }
                         } else {


### PR DESCRIPTION
Hi, I find this bug in my new project with activating the range generation option.

Without this change, in `ToSpan` impls, it outputs `Boolean::BooleanTrue(v) => v.span(),` instead of `Boolean::True(v) => v.span(),` for grammars like `Boolean: True | False`, and `ASTType::UNNAMED(v) => {` for grammar symbols with `*Opt` suffix.

I have tried to add failing tests about this, but I cannot figure out a proper place to have this test case and test data.