### PR TITLE
Allow needless_lifetimes for ToSpan generation

### DIFF
--- a/crates/parol/src/generators/template_data.rs
+++ b/crates/parol/src/generators/template_data.rs
@@ -440,6 +440,7 @@ impl std::fmt::Display for RangeCalculation {
             code,
         } = self;
         f.write_fmt(ume::ume! {
+            #[allow(clippy::needless_lifetimes)]
             impl #lifetime ToSpan for #type_name #lifetime {
                 fn span(&self) -> Span {
                     #code


### PR DESCRIPTION
Without the attribute, clippy emits the following:
```
warning: the following explicit lifetimes could be elided: 't
    --> crates\swon-parol\src\grammar_trait.rs:1580:6
     |
1580 | impl<'t> ToSpan for ASTType<'t> {
     |      ^^                     ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1580 - impl<'t> ToSpan for ASTType<'t> {
1580 + impl ToSpan for ASTType<'_> {
```