### PR TITLE
Allow user to generate typed syntree

### DIFF
--- a/crates/parol/src/generators/grammar_config.rs
+++ b/crates/parol/src/generators/grammar_config.rs
@@ -170,7 +170,7 @@ impl GrammarConfig {
             .map(|(i, (t, _, _, _))| (i + 5, t))
             .fold(names, |mut acc, (i, t)| {
                 let name = generate_name(
-                    &acc,
+                    acc.iter(),
                     generate_terminal_name(t, Some(i as TerminalIndex), &self.cfg),
                 );
                 acc.push(name);

--- a/crates/parol/src/generators/grammar_type_generator.rs
+++ b/crates/parol/src/generators/grammar_type_generator.rs
@@ -2,7 +2,7 @@ use crate::analysis::lookahead_dfa::ProductionIndex;
 use crate::generators::NamingHelper as NmHlp;
 use crate::grammar::ProductionAttribute;
 use crate::parser::GrammarType;
-use crate::{Pr, Symbol, Terminal};
+use crate::{generate_name, Pr, Symbol, Terminal};
 use anyhow::{anyhow, bail, Result};
 use parol_runtime::log::trace;
 use std::collections::{BTreeMap, HashSet};
@@ -795,13 +795,16 @@ impl GrammarTypeInfo {
         Ok(())
     }
 
-    pub(crate) fn generate_non_terminal_enum_type(
-        &self,
-    ) -> impl Iterator<Item = (&str, &str)> + Clone {
-        self.non_terminal_types
-            .keys()
-            .map(|n| (n.as_str(), n.as_str()))
-            .chain(std::iter::once(("Root", "")))
+    pub(crate) fn generate_non_terminal_enum_type(&self) -> Vec<(String, &str)> {
+        let mut result = Vec::with_capacity(self.non_terminal_types.len() + 1);
+        for (n, _) in self.non_terminal_types.iter() {
+            result.push((n.to_string(), n.as_str()));
+        }
+        result.push((
+            generate_name(self.non_terminal_types.keys(), "Root".to_string()),
+            "",
+        ));
+        result
     }
 
     // Generates an enum variant name for the given production from its right-hand side. If the

--- a/crates/parol/src/generators/lexer_generator.rs
+++ b/crates/parol/src/generators/lexer_generator.rs
@@ -141,7 +141,7 @@ pub fn generate_lexer_source(grammar_config: &GrammarConfig) -> Result<String> {
             .enumerate()
             .fold(Vec::new(), |mut acc, (i, e)| {
                 let n = generate_name(
-                    &acc,
+                    acc.iter(),
                     generate_terminal_name(&e.0, Some(i as TerminalIndex), &grammar_config.cfg),
                 );
                 acc.push(n);
@@ -195,7 +195,7 @@ pub fn generate_terminal_names(grammar_config: &GrammarConfig) -> Vec<String> {
         .enumerate()
         .fold(Vec::new(), |mut acc, (i, e)| {
             let n = generate_name(
-                &acc,
+                acc.iter(),
                 generate_terminal_name(&e.0, Some(i as TerminalIndex), &grammar_config.cfg),
             );
             acc.push(n);

--- a/crates/parol/src/generators/symbol_table.rs
+++ b/crates/parol/src/generators/symbol_table.rs
@@ -484,7 +484,7 @@ impl Scope {
         if preferred_name == SymbolTable::UNNAMED_TYPE {
             SymbolTable::UNNAMED_TYPE.to_string()
         } else {
-            generate_name(&self.names, preferred_name)
+            generate_name(self.names.iter(), preferred_name)
         }
     }
 

--- a/crates/parol/src/generators/syntree_node_types_generator.rs
+++ b/crates/parol/src/generators/syntree_node_types_generator.rs
@@ -56,6 +56,7 @@ impl SyntreeNodeTypesGenerator<'_> {
         terminal.push(String::default());
         let non_terminal_enum = grammar_type_info
             .generate_non_terminal_enum_type()
+            .into_iter()
             .map(|(variant, _)| format!("{}", ume::ume!(#variant,)))
             .collect::<StrVec>();
         let terminal_enum = self
@@ -99,6 +100,7 @@ impl SyntreeNodeTypesGenerator<'_> {
 
         let non_terminal_match_arms = grammar_type_info
             .generate_non_terminal_enum_type()
+            .into_iter()
             .map(|(variant, name)| NameToNonTerminalVariant {
                 variant: variant.to_owned(),
                 name: name.to_owned(),
@@ -154,8 +156,9 @@ impl SyntreeNodeTypesGenerator<'_> {
             })
             .into_str_iter();
 
-        let non_terminal_arms = grammar_type_info
-            .generate_non_terminal_enum_type()
+        let non_terminals = grammar_type_info.generate_non_terminal_enum_type();
+        let non_terminal_arms = non_terminals
+            .iter()
             .map(|(variant, name)| DisplayArm {
                 variant,
                 value: name,
@@ -479,18 +482,6 @@ impl SyntreeNodeTypesGenerator<'_> {
 
     fn child_kind(&self, symbol: &crate::Symbol) -> Option<ChildKind> {
         match symbol {
-            crate::Symbol::N(s, SymbolAttribute::Clipped, _) => Some(ChildKind {
-                kind: ChildNodeKind::NonTerminal,
-                name: s.clone(),
-                attribute: ChildAttribute::Clipped,
-            }),
-            crate::Symbol::T(Terminal::Trm(terminal, _, _, SymbolAttribute::Clipped, _, _)) => {
-                Some(ChildKind {
-                    kind: ChildNodeKind::Terminal,
-                    name: generate_terminal_name(terminal, None, &self.grammar_config.cfg),
-                    attribute: ChildAttribute::Clipped,
-                })
-            }
             crate::Symbol::N(s, attrs, _) => match attrs {
                 SymbolAttribute::Option => Some(ChildKind {
                     kind: ChildNodeKind::NonTerminal,
@@ -502,7 +493,12 @@ impl SyntreeNodeTypesGenerator<'_> {
                     name: s.clone(),
                     attribute: ChildAttribute::Vec,
                 }),
-                _ => Some(ChildKind {
+                SymbolAttribute::Clipped => Some(ChildKind {
+                    kind: ChildNodeKind::NonTerminal,
+                    name: s.clone(),
+                    attribute: ChildAttribute::Clipped,
+                }),
+                SymbolAttribute::None => Some(ChildKind {
                     kind: ChildNodeKind::NonTerminal,
                     name: s.clone(),
                     attribute: ChildAttribute::Normal,
@@ -519,7 +515,12 @@ impl SyntreeNodeTypesGenerator<'_> {
                     name: generate_terminal_name(terminal, None, &self.grammar_config.cfg),
                     attribute: ChildAttribute::Vec,
                 }),
-                _ => Some(ChildKind {
+                SymbolAttribute::Clipped => Some(ChildKind {
+                    kind: ChildNodeKind::Terminal,
+                    name: generate_terminal_name(terminal, None, &self.grammar_config.cfg),
+                    attribute: ChildAttribute::Clipped,
+                }),
+                SymbolAttribute::None => Some(ChildKind {
                     kind: ChildNodeKind::Terminal,
                     name: generate_terminal_name(terminal, None, &self.grammar_config.cfg),
                     attribute: ChildAttribute::Normal,

--- a/crates/parol/src/generators/syntree_node_types_generator.rs
+++ b/crates/parol/src/generators/syntree_node_types_generator.rs
@@ -7,7 +7,9 @@ use crate::utils::str_iter::IteratorExt;
 use crate::{StrVec, SymbolAttribute, Terminal};
 
 use super::grammar_type_generator::GrammarTypeInfo;
-use super::template_data::{ChildKind, DisplayArm, NumToTerminalVariant};
+use super::template_data::{
+    ChildAttribute, ChildKind, ChildNodeKind, DisplayArm, NumToTerminalVariant,
+};
 use super::{generate_terminal_name, GrammarConfig};
 
 /// Syntree node types generator.
@@ -282,6 +284,9 @@ impl SyntreeNodeTypesGenerator<'_> {
                 // Does not need to generate multiple find methods for the same child kind.
                 let mut exists = BTreeSet::new();
                 for child_kind in child_kinds.children {
+                    if child_kind.attribute == ChildAttribute::Clipped {
+                        continue;
+                    }
                     if exists.insert(child_kind.print_find_method_name()) {
                         self.generate_find_methods_sequence_single(f, pr, child_kind)?;
                     }
@@ -307,6 +312,9 @@ impl SyntreeNodeTypesGenerator<'_> {
         })?;
         write!(f, "{{")?;
         for child_kind in child_kinds.children {
+            if child_kind.attribute == ChildAttribute::Clipped {
+                continue;
+            }
             let variant = child_kind.print_ast_enum_variant();
             write!(f, "{}", variant)?;
         }
@@ -324,16 +332,19 @@ impl SyntreeNodeTypesGenerator<'_> {
         let variants = child_kinds
             .children
             .iter()
+            .filter(|child| child.attribute != ChildAttribute::Clipped)
             .map(|child| child.print_enum_new_match_arms())
             .into_str_iter();
         let node_match_arms = child_kinds
             .children
             .iter()
+            .filter(|child| child.attribute != ChildAttribute::Clipped)
             .map(|child| child.print_enum_node_match_arms())
             .into_str_iter();
         let node_match_arms_mut = child_kinds
             .children
             .iter()
+            .filter(|child| child.attribute != ChildAttribute::Clipped)
             .map(|child| child.print_enum_node_mut_match_arms())
             .into_str_iter();
         f.write_fmt(ume::ume! {
@@ -468,25 +479,51 @@ impl SyntreeNodeTypesGenerator<'_> {
 
     fn child_kind(&self, symbol: &crate::Symbol) -> Option<ChildKind> {
         match symbol {
-            crate::Symbol::N(_, SymbolAttribute::Clipped, _) => None,
-            crate::Symbol::T(Terminal::Trm(_, _, _, SymbolAttribute::Clipped, _, _)) => None,
+            crate::Symbol::N(s, SymbolAttribute::Clipped, _) => Some(ChildKind {
+                kind: ChildNodeKind::NonTerminal,
+                name: s.clone(),
+                attribute: ChildAttribute::Clipped,
+            }),
+            crate::Symbol::T(Terminal::Trm(terminal, _, _, SymbolAttribute::Clipped, _, _)) => {
+                Some(ChildKind {
+                    kind: ChildNodeKind::Terminal,
+                    name: generate_terminal_name(terminal, None, &self.grammar_config.cfg),
+                    attribute: ChildAttribute::Clipped,
+                })
+            }
             crate::Symbol::N(s, attrs, _) => match attrs {
-                SymbolAttribute::Option => Some(ChildKind::OptionalNonTerminal(s.clone())),
-                SymbolAttribute::RepetitionAnchor => Some(ChildKind::VecNonTerminal(s.clone())),
-                _ => Some(ChildKind::NonTerminal(s.clone())),
+                SymbolAttribute::Option => Some(ChildKind {
+                    kind: ChildNodeKind::NonTerminal,
+                    name: s.clone(),
+                    attribute: ChildAttribute::Optional,
+                }),
+                SymbolAttribute::RepetitionAnchor => Some(ChildKind {
+                    kind: ChildNodeKind::NonTerminal,
+                    name: s.clone(),
+                    attribute: ChildAttribute::Vec,
+                }),
+                _ => Some(ChildKind {
+                    kind: ChildNodeKind::NonTerminal,
+                    name: s.clone(),
+                    attribute: ChildAttribute::Normal,
+                }),
             },
             crate::Symbol::T(Terminal::Trm(terminal, _, _, attrs, _, _)) => match attrs {
-                SymbolAttribute::Option => Some(ChildKind::OptionalTerminal(
-                    generate_terminal_name(terminal, None, &self.grammar_config.cfg),
-                )),
-                SymbolAttribute::RepetitionAnchor => Some(ChildKind::VecTerminal(
-                    generate_terminal_name(terminal, None, &self.grammar_config.cfg),
-                )),
-                _ => Some(ChildKind::Terminal(generate_terminal_name(
-                    terminal,
-                    None,
-                    &self.grammar_config.cfg,
-                ))),
+                SymbolAttribute::Option => Some(ChildKind {
+                    kind: ChildNodeKind::Terminal,
+                    name: generate_terminal_name(terminal, None, &self.grammar_config.cfg),
+                    attribute: ChildAttribute::Optional,
+                }),
+                SymbolAttribute::RepetitionAnchor => Some(ChildKind {
+                    kind: ChildNodeKind::Terminal,
+                    name: generate_terminal_name(terminal, None, &self.grammar_config.cfg),
+                    attribute: ChildAttribute::Vec,
+                }),
+                _ => Some(ChildKind {
+                    kind: ChildNodeKind::Terminal,
+                    name: generate_terminal_name(terminal, None, &self.grammar_config.cfg),
+                    attribute: ChildAttribute::Normal,
+                }),
             },
             crate::Symbol::T(Terminal::Eps) => None,
             crate::Symbol::T(Terminal::End) => None,

--- a/crates/parol/src/transformation/canonicalization.rs
+++ b/crates/parol/src/transformation/canonicalization.rs
@@ -165,7 +165,7 @@ fn extract_options(opd: TransformationOperand) -> TransformationOperand {
                     } else {
                         format!("{}Opt", non_terminal)
                     };
-                    let new_opt_production_name = generate_name(exclusions, preferred_name);
+                    let new_opt_production_name = generate_name(exclusions.iter(), preferred_name);
                     *factor = Factor::NonTerminal(
                         new_opt_production_name.clone(),
                         SymbolAttribute::Option,
@@ -361,7 +361,7 @@ fn eliminate_single_rep(
         .iter()
         .position(|f| matches!(f, Factor::Repeat(_)))
     {
-        let r_tick_name = generate_name(exclusions, production_name + "List");
+        let r_tick_name = generate_name(exclusions.iter(), production_name + "List");
         if let Factor::Repeat(repeat) = production.rhs.0[alt_index].0[rpt_index_in_alt].clone() {
             let mut production1 = production.clone();
             production1.rhs.0[alt_index].0[rpt_index_in_alt] =
@@ -503,7 +503,7 @@ fn eliminate_single_opt(
                 vec![production1, production1a]
             } else {
                 // Case 2
-                let r_tick_name = generate_name(exclusions, production_name + "Opt");
+                let r_tick_name = generate_name(exclusions.iter(), production_name + "Opt");
                 let mut production1 = production.clone();
                 production1.rhs.0[alt_index].0[opt_index_in_alt] =
                     Factor::default_non_terminal(r_tick_name.clone());
@@ -602,7 +602,7 @@ fn eliminate_single_grp(
                 vec![production1]
             } else {
                 // Case 2
-                let g_name = generate_name(exclusions, production_name + "Group");
+                let g_name = generate_name(exclusions.iter(), production_name + "Group");
                 if let Factor::Group(group) =
                     production.rhs.0[alt_index].0[grp_index_in_alt].clone()
                 {

--- a/crates/parol/src/transformation/left_factoring.rs
+++ b/crates/parol/src/transformation/left_factoring.rs
@@ -215,7 +215,7 @@ pub fn left_factor(g: &Cfg) -> Cfg {
         // A' -> suffix1|suffix2|... i.e. A' -> suffix1;  A' -> suffix2;  ...
         let first_rule = &rules[0];
         let suffix_rule_name =
-            generate_name(exclusions, first_rule.get_n_str().to_owned() + "Suffix");
+            generate_name(exclusions.iter(), first_rule.get_n_str().to_owned() + "Suffix");
         let mut prod = prefix.to_owned();
         prod.push(Symbol::n(&suffix_rule_name));
         let prefix_rule = Pr::new(first_rule.get_n_str(), prod);

--- a/crates/parol/src/transformation/lr_augmentation.rs
+++ b/crates/parol/src/transformation/lr_augmentation.rs
@@ -10,10 +10,7 @@ pub fn augment_grammar(cfg: &Cfg) -> Cfg {
         return cfg.clone();
     }
     let mut new_cfg = cfg.clone();
-    let new_start = generate_name(
-        &cfg.get_non_terminal_set().iter().collect::<Vec<_>>(),
-        cfg.st.clone(),
-    );
+    let new_start = generate_name(cfg.get_non_terminal_set().iter(), cfg.st.clone());
     new_cfg.st.clone_from(&new_start);
     new_cfg.pr.insert(
         0,

--- a/crates/parol/src/utils/mod.rs
+++ b/crates/parol/src/utils/mod.rs
@@ -43,24 +43,31 @@ where
 /// Generates a new unique name avoiding collisions with the names given in the 'exclusions'.
 /// It takes a preferred name and if it collides it adds an increasing suffix number.
 /// If the preferred name already has a suffix number it starts counting up from this number.
-pub(crate) fn generate_name<T>(exclusions: &[T], preferred_name: String) -> String
+pub(crate) fn generate_name<T>(
+    exclusions: impl Iterator<Item = T> + Clone,
+    preferred_name: String,
+) -> String
 where
     T: AsRef<str>,
 {
-    fn gen_name<T>(exclusions: &[T], prefix: String, start_num: usize) -> String
+    fn gen_name<T>(
+        exclusions: impl Iterator<Item = T> + Clone,
+        prefix: String,
+        start_num: usize,
+    ) -> String
     where
         T: AsRef<str>,
     {
         let mut num = start_num;
         let mut new_name = format!("{}{}", prefix, num);
-        while exclusions.iter().any(|n| n.as_ref() == new_name) {
+        while exclusions.clone().any(|n| n.as_ref() == new_name) {
             num += 1;
             new_name = format!("{}{}", prefix, num);
         }
         new_name
     }
 
-    if exclusions.iter().any(|n| n.as_ref() == preferred_name) {
+    if exclusions.clone().any(|n| n.as_ref() == preferred_name) {
         let (suffix_number, prefix) = {
             if let Some(match_) = RX_NUM_SUFFIX.find(&preferred_name) {
                 let num = match_.as_str().parse::<usize>().unwrap_or(1);

--- a/crates/parol_runtime/src/parser/parse_tree_type.rs
+++ b/crates/parol_runtime/src/parser/parse_tree_type.rs
@@ -179,6 +179,8 @@ pub struct ChildKind<T, Nt> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 /// The attribute of a child kind.
 pub enum ChildAttribute {
+    /// A clipped child kind.
+    Clipped,
     /// A normal child kind.
     Normal,
     /// An optional child kind.

--- a/examples/calc/calc_nodes.rs
+++ b/examples/calc/calc_nodes.rs
@@ -387,6 +387,10 @@ impl ExpectedChildren<TerminalKind, NonTerminalKind> for NonTerminalKind {
                     attribute: ChildAttribute::Normal,
                 },
                 ChildKind {
+                    kind: NodeKind::Terminal(TerminalKind::Semicolon),
+                    attribute: ChildAttribute::Clipped,
+                },
+                ChildKind {
                     kind: NodeKind::NonTerminal(NonTerminalKind::CalcList),
                     attribute: ChildAttribute::Normal,
                 },
@@ -431,6 +435,10 @@ impl ExpectedChildren<TerminalKind, NonTerminalKind> for NonTerminalKind {
                 ChildKind {
                     kind: NodeKind::NonTerminal(NonTerminalKind::Negate),
                     attribute: ChildAttribute::Normal,
+                },
+                ChildKind {
+                    kind: NodeKind::Terminal(TerminalKind::LParen),
+                    attribute: ChildAttribute::Clipped,
                 },
             ]),
             Self::Id => ExpectedChildrenKinds::Sequence(&[ChildKind {

--- a/examples/calc_lr/calc_nodes.rs
+++ b/examples/calc_lr/calc_nodes.rs
@@ -390,6 +390,10 @@ impl ExpectedChildren<TerminalKind, NonTerminalKind> for NonTerminalKind {
                     kind: NodeKind::NonTerminal(NonTerminalKind::Instruction),
                     attribute: ChildAttribute::Normal,
                 },
+                ChildKind {
+                    kind: NodeKind::Terminal(TerminalKind::Semicolon),
+                    attribute: ChildAttribute::Clipped,
+                },
             ]),
             Self::Equality => ExpectedChildrenKinds::Sequence(&[
                 ChildKind {
@@ -431,6 +435,10 @@ impl ExpectedChildren<TerminalKind, NonTerminalKind> for NonTerminalKind {
                 ChildKind {
                     kind: NodeKind::NonTerminal(NonTerminalKind::IdRef),
                     attribute: ChildAttribute::Normal,
+                },
+                ChildKind {
+                    kind: NodeKind::Terminal(TerminalKind::LParen),
+                    attribute: ChildAttribute::Clipped,
                 },
             ]),
             Self::Id => ExpectedChildrenKinds::Sequence(&[ChildKind {


### PR DESCRIPTION
## Motivation

Currently, the parsed syntree is untyped, making it difficult to traverse and analyze in a type-safe manner, as well as to create wrappers around it.

## What changed

- Added `TerminalEnum` and `NonTerminalEnum` traits in the runtime crate
- Generate `TerminalKind` and `NonTerminalKind` enums for all LL or LALR grammar
- Generate `TerminalEnum::from_terminal_index` and `NonTerminalEnum::from_non_terminal_name` for conversion
- Introduce the `SynTreeNode`  trait in the runtime crate.
- Generate the `parse2` (corresponding to the existing `parse` function)  method that can produce a syntree with any node type that implements the `SynTreeNode`
- Add the `SynTree2` enum which corresponds to the existing `SynTree` 

## Need to consider

- [ ] Choose better names for the new types and traits
- [x] ~~Decide whether parol_runtime should provide these traits and the `SynTree2` type, or if they should be user-defined~~
  Initially proposed `SynTree2` not provided from parol_runtime crate but a user can define their corresponding structure.
- [x] ~~Confirm whether the `TerminalData::Dynamic` variant is viable. It could allow tree modifications (e.g., for formatting or applying code actions in an LSP context).~~
  `SynTree2` was using `TerminalData` in the definition but `SynTree2` was removed from the proposal.

## Next step

I'd like to add an option to parol to generate `SynTree2` wrappers for each AST type to help handling `syntree::Node<SynTree2<T>>` in a type-safe way.

For example,

```rust
struct Array(syntree::Node<SynTree2<MyGrammar>>;

// For non-terminal
impl Array {
    pub fn find_array_begin(&self) -> Option<ArrayBegin> { ... }
    pub fn find_array_items(&self) -> Vec<ArrayItem> { ... }
    pub fn find_array_end(&self) -> Option<ArrayEnd> { ... }
}

struct ArrayBegin(syntree::Node<SynTree2<MyGrammar>>;

// For terminal
impl ArrayBegin {
    pub fn token(&self) -> Token {
        ...
    }
}
```

## TODO

- [x] Generate `TerminalKind` and `NonTerminalKind`
- [x] Generate `ExpectedChildren`
- [x] Generate the `parse_into` function to parse into any tree with `TreeConstruct` trait
- [x] Generate node wrapper for each production both struct and enum, and implement cursor-based `find_*` methods.
- [x] (Bug) `find_*` methods conflict if a production has multiple same inner production.
- [x] (Bug) Current generation of ExpectedChildren and enum wrappers may be wrong. `ExpectedChildrenKinds` needs extra two variants `SequenceOrEmpty` and `SomeOrEmpty`.
- [ ] Generate helper method to exhaustively extract children nodes at once in atype-safe manner. 
- [ ] Generate helper method like `fn children(&self) -> impl Iterator<Item = T>` for Vec-like production.