### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, release1.0 ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/jsinger67/parol/security/code-scanning/1](https://github.com/jsinger67/parol/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the tasks performed in the workflow (building, testing, and checking for changes). This change ensures that the workflow does not inherit unnecessary write permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
